### PR TITLE
Add Jest tests for upload function

### DIFF
--- a/netlify/functions/upload.js
+++ b/netlify/functions/upload.js
@@ -10,7 +10,7 @@ cloudinary.config({
   api_secret: process.env.CLOUDINARY_API_SECRET,
 });
 
-exports.handler = (event, context, callback) => {
+const handler = (event, context, callback) => {
   // Only accept POST requests
   if (event.httpMethod !== 'POST') {
     return callback(null, {
@@ -64,3 +64,5 @@ exports.handler = (event, context, callback) => {
   // Parse the request body with Busboy
   busboy.end(Buffer.from(event.body, event.isBase64Encoded ? 'base64' : 'utf8'));
 };
+
+module.exports.handler = handler;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -19,6 +19,9 @@
   "dependencies": {
     "busboy": "^1.6.0",
     "cloudinary": "^2.6.0"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
   },
   "description": ""
 }

--- a/tests/upload.test.js
+++ b/tests/upload.test.js
@@ -1,0 +1,59 @@
+
+jest.mock('cloudinary', () => {
+  return {
+    v2: {
+      config: jest.fn(),
+      uploader: {
+        upload_stream: jest.fn()
+      }
+    }
+  };
+});
+
+const cloudinary = require('cloudinary');
+const { handler } = require('../netlify/functions/upload');
+
+function runHandler(event) {
+  return new Promise((resolve, reject) => {
+    handler(event, {}, (err, res) => {
+      if (err) reject(err);
+      else resolve(res);
+    });
+  });
+}
+
+describe('upload handler', () => {
+  test('returns 405 for non-POST', async () => {
+    const result = await runHandler({ httpMethod: 'GET' });
+    expect(result.statusCode).toBe(405);
+  });
+
+  test('handles POST upload', async () => {
+    const boundary = '----testboundary';
+    const filename = 'test.txt';
+    const body = `--${boundary}\r\n` +
+      `Content-Disposition: form-data; name="file"; filename="${filename}"\r\n` +
+      'Content-Type: text/plain\r\n\r\n' +
+      'hello world\r\n' +
+      `--${boundary}--\r\n`;
+
+    let receivedOptions;
+    cloudinary.v2.uploader.upload_stream.mockImplementation((options, cb) => {
+      receivedOptions = options;
+      return {
+        end: () => cb(null, { secure_url: `http://example.com/${options.public_id}` })
+      };
+    });
+
+    const result = await runHandler({
+      httpMethod: 'POST',
+      headers: { 'content-type': `multipart/form-data; boundary=${boundary}` },
+      body,
+      isBase64Encoded: false
+    });
+
+    expect(receivedOptions.public_id).toBe(filename);
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toEqual({ url: `http://example.com/${filename}` });
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest as a dev dependency and configure the test script
- export `handler` function for use in tests
- add tests covering POST and non-POST events

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684024cb89248330b4eef8681bd9fa1b