### PR TITLE
Integrate Google Cloud Vision tagging

### DIFF
--- a/index.html
+++ b/index.html
@@ -2411,7 +2411,28 @@ function closeEnlargeModal() {
 });
 
     // Add this function just before your processUpload function
+
 async function generateImageTags(imageUrl) {
+  try {
+    const res = await fetch('/.netlify/functions/cloudVision', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ imageUrl })
+    });
+    if (res.ok) {
+      const data = await res.json();
+      if (data.tags !== undefined) {
+        return data;
+      }
+    }
+    throw new Error('Cloud Vision failed');
+  } catch (err) {
+    console.warn('Cloud Vision API error, falling back to MobileNet:', err);
+    return await generateImageTagsWithMobileNet(imageUrl);
+  }
+}
+
+async function generateImageTagsWithMobileNet(imageUrl) {
   try {
     console.log("Starting tag generation for image:", imageUrl);
     

--- a/netlify/functions/cloudVision.js
+++ b/netlify/functions/cloudVision.js
@@ -1,0 +1,52 @@
+const fetch = global.fetch || require('node-fetch');
+
+exports.handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, body: 'Method Not Allowed' };
+  }
+
+  try {
+    const { imageUrl } = JSON.parse(event.body || '{}');
+    if (!imageUrl) {
+      return { statusCode: 400, body: 'Missing imageUrl' };
+    }
+
+    const apiKey = process.env.VISION_API_KEY;
+    if (!apiKey) {
+      return { statusCode: 500, body: 'Missing API key' };
+    }
+
+    const body = {
+      requests: [
+        {
+          image: { source: { imageUri: imageUrl } },
+          features: [{ type: 'LABEL_DETECTION', maxResults: 5 }]
+        }
+      ]
+    };
+
+    const response = await fetch(`https://vision.googleapis.com/v1/images:annotate?key=${apiKey}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      return { statusCode: response.status, body: text };
+    }
+
+    const data = await response.json();
+    const labels = (data.responses && data.responses[0].labelAnnotations) || [];
+
+    const tags = labels.map(l => l.description.toLowerCase()).slice(0,5).join(', ');
+    const possibleObjects = labels.map(l => ({ name: l.description.toLowerCase(), confidence: l.score }));
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ tags, possibleObjects })
+    };
+  } catch (err) {
+    return { statusCode: 500, body: JSON.stringify({ error: err.message }) };
+  }
+};


### PR DESCRIPTION
## Summary
- add a Netlify function `cloudVision.js` to query Google Cloud Vision
- update `generateImageTags` in `index.html` to use the new API and fall back to MobileNet

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node -e "require('./netlify/functions/cloudVision.js'); console.log('ok')"`

------
https://chatgpt.com/codex/tasks/task_e_6840223121c4833084e3f3a59a9d7bad