### PR TITLE
Prevent Cloudinary uploads from overwriting

### DIFF
--- a/netlify/functions/upload.js
+++ b/netlify/functions/upload.js
@@ -48,9 +48,12 @@ const handler = (event, context, callback) => {
 
   // When Busboy is done parsing
   busboy.on('finish', () => {
+    // Generate a unique public_id to avoid overwriting existing images
+    const uniqueFileName = `${Date.now()}-${fileName}`;
+
     // Upload to Cloudinary
     const uploadStream = cloudinary.uploader.upload_stream(
-      { resource_type: 'auto', public_id: fileName },
+      { resource_type: 'auto', public_id: uniqueFileName },
       (error, result) => {
         if (error) {
           console.error('Cloudinary Upload Error:', error);

--- a/tests/upload.test.js
+++ b/tests/upload.test.js
@@ -52,8 +52,9 @@ describe('upload handler', () => {
       isBase64Encoded: false
     });
 
-    expect(receivedOptions.public_id).toBe(filename);
+    expect(receivedOptions.public_id).toContain(filename);
+    expect(receivedOptions.public_id).not.toBe(filename);
     expect(result.statusCode).toBe(200);
-    expect(JSON.parse(result.body)).toEqual({ url: `http://example.com/${filename}` });
+    expect(JSON.parse(result.body)).toEqual({ url: `http://example.com/${receivedOptions.public_id}` });
   });
 });


### PR DESCRIPTION
## Summary
- generate a unique filename before uploading to Cloudinary
- update tests to expect unique public IDs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68404c4e790c8330b0e0268d39aef1e8