### PR TITLE
Fix tag generation

### DIFF
--- a/index.html
+++ b/index.html
@@ -2546,12 +2546,7 @@ async function generateImageTagsWithMobileNet(imageUrl) {
       return 0;
     });
 
-    // Ensure at least five tags are returned
-    while (processedTags.length < 5) {
-      processedTags.push('unknown');
-    }
-
-    // Take only the top 5 tags after processing
+    // Take up to the top 5 tags after processing
     const tags = processedTags.slice(0, 5).join(', ');
     
     console.log("Generated tags:", tags);

--- a/netlify/functions/cloudVision.js
+++ b/netlify/functions/cloudVision.js
@@ -41,10 +41,6 @@ exports.handler = async (event) => {
     const labels = (data.responses && data.responses[0].labelAnnotations) || [];
 
     const tagNames = labels.map(l => l.description.toLowerCase());
-    while (tagNames.length < 5) {
-      tagNames.push('unknown');
-    }
-
     const tags = tagNames.slice(0, 5).join(', ');
     const possibleObjects = labels.map(l => ({ name: l.description.toLowerCase(), confidence: l.score }));
 


### PR DESCRIPTION
## Summary
- avoid adding `unknown` filler tags in Google Vision function
- remove `unknown` filler logic from fallback MobileNet tagging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68404e677ccc8330b7254359d4ac2035