### PR TITLE
Merge main and resolve conflicts for AI tagging improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -2485,9 +2485,10 @@ async function generateImageTagsWithMobileNet(imageUrl) {
     ];
 
     // Generic tag expansions to ensure at least five results
+    // Map specific tags to more global categories and synonyms
     const generalTagMappings = {
-      soup: ['food', 'dish', 'meal', 'liquid'],
-      salad: ['food', 'dish', 'meal', 'vegetable'],
+      soup: ['food', 'dish', 'meal', 'liquid', 'broth'],
+      salad: ['food', 'dish', 'meal', 'vegetable', 'greens'],
       car: ['vehicle', 'transport', 'auto'],
       cat: ['animal', 'pet', 'feline'],
       dog: ['animal', 'pet', 'canine'],

--- a/netlify/functions/cloudVision.js
+++ b/netlify/functions/cloudVision.js
@@ -27,8 +27,8 @@ exports.handler = async (event) => {
     };
 
     const generalTagMappings = {
-      soup: ['food', 'dish', 'meal', 'liquid'],
-      salad: ['food', 'dish', 'meal', 'vegetable'],
+      soup: ['food', 'dish', 'meal', 'liquid', 'broth'],
+      salad: ['food', 'dish', 'meal', 'vegetable', 'greens'],
       car: ['vehicle', 'transport', 'auto'],
       cat: ['animal', 'pet', 'feline'],
       dog: ['animal', 'pet', 'canine'],


### PR DESCRIPTION
## Summary
- merge main into work and resolve conflicts
- ensure tag expansion fallback remains in index.html
- keep enriched tagging logic in cloudVision function

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68404e677ccc8330b7254359d4ac2035