### PR TITLE
Expand general tag mappings

### DIFF
--- a/index.html
+++ b/index.html
@@ -2479,10 +2479,25 @@ async function generateImageTagsWithMobileNet(imageUrl) {
     
     // Define categories to favor for reference images
     const textureCategories = [
-      'brick', 'stone', 'wood', 'metal', 'concrete', 'fabric', 'leather', 
+      'brick', 'stone', 'wood', 'metal', 'concrete', 'fabric', 'leather',
       'grass', 'dirt', 'sand', 'rock', 'water', 'sky', 'cloud', 'fire',
       'rust', 'paint', 'glass', 'ceramic', 'plastic', 'paper', 'cardboard'
     ];
+
+    // Generic tag expansions to ensure at least five results
+    // Map specific tags to more global categories and synonyms
+    const generalTagMappings = {
+      soup: ['food', 'dish', 'meal', 'liquid', 'broth'],
+      salad: ['food', 'dish', 'meal', 'vegetable', 'greens'],
+      car: ['vehicle', 'transport', 'auto'],
+      cat: ['animal', 'pet', 'feline'],
+      dog: ['animal', 'pet', 'canine'],
+      tree: ['plant', 'nature', 'wood'],
+      building: ['architecture', 'structure', 'construction'],
+      phone: ['electronics', 'device', 'smartphone'],
+      person: ['human', 'people', 'individual'],
+      computer: ['electronics', 'device', 'technology']
+    };
     
     // Manual corrections for common objects
     const specialObjects = {
@@ -2546,12 +2561,23 @@ async function generateImageTagsWithMobileNet(imageUrl) {
       return 0;
     });
 
-    // Ensure at least five tags are returned
-    while (processedTags.length < 5) {
-      processedTags.push('unknown');
+    // Expand with general categories if fewer than five tags
+    if (processedTags.length < 5) {
+      for (const tag of [...processedTags]) {
+        const extras = generalTagMappings[tag];
+        if (extras) {
+          for (const extra of extras) {
+            if (processedTags.length >= 5) break;
+            if (!processedTags.includes(extra)) {
+              processedTags.push(extra);
+            }
+          }
+        }
+        if (processedTags.length >= 5) break;
+      }
     }
 
-    // Take only the top 5 tags after processing
+    // Take up to the top 5 tags after processing
     const tags = processedTags.slice(0, 5).join(', ');
     
     console.log("Generated tags:", tags);

--- a/netlify/functions/cloudVision.js
+++ b/netlify/functions/cloudVision.js
@@ -26,6 +26,19 @@ exports.handler = async (event) => {
       ]
     };
 
+    const generalTagMappings = {
+      soup: ['food', 'dish', 'meal', 'liquid', 'broth'],
+      salad: ['food', 'dish', 'meal', 'vegetable', 'greens'],
+      car: ['vehicle', 'transport', 'auto'],
+      cat: ['animal', 'pet', 'feline'],
+      dog: ['animal', 'pet', 'canine'],
+      tree: ['plant', 'nature', 'wood'],
+      building: ['architecture', 'structure', 'construction'],
+      phone: ['electronics', 'device', 'smartphone'],
+      person: ['human', 'people', 'individual'],
+      computer: ['electronics', 'device', 'technology']
+    };
+
     const response = await fetch(`https://vision.googleapis.com/v1/images:annotate?key=${apiKey}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -41,11 +54,23 @@ exports.handler = async (event) => {
     const labels = (data.responses && data.responses[0].labelAnnotations) || [];
 
     const tagNames = labels.map(l => l.description.toLowerCase());
-    while (tagNames.length < 5) {
-      tagNames.push('unknown');
+    let processedTags = [...tagNames];
+    if (processedTags.length < 5) {
+      for (const tag of [...tagNames]) {
+        const extras = generalTagMappings[tag];
+        if (extras) {
+          for (const extra of extras) {
+            if (processedTags.length >= 5) break;
+            if (!processedTags.includes(extra)) {
+              processedTags.push(extra);
+            }
+          }
+        }
+        if (processedTags.length >= 5) break;
+      }
     }
 
-    const tags = tagNames.slice(0, 5).join(', ');
+    const tags = processedTags.slice(0, 5).join(', ');
     const possibleObjects = labels.map(l => ({ name: l.description.toLowerCase(), confidence: l.score }));
 
     return {


### PR DESCRIPTION
## Summary
- ensure tags include general categories when fewer than five results are found
- update tag mappings with extra synonyms (e.g. "broth" for soup)

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68404e677ccc8330b7254359d4ac2035