### PR TITLE
Resolve tag fallbacks

### DIFF
--- a/index.html
+++ b/index.html
@@ -2479,10 +2479,36 @@ async function generateImageTagsWithMobileNet(imageUrl) {
     
     // Define categories to favor for reference images
     const textureCategories = [
-      'brick', 'stone', 'wood', 'metal', 'concrete', 'fabric', 'leather', 
+      'brick', 'stone', 'wood', 'metal', 'concrete', 'fabric', 'leather',
       'grass', 'dirt', 'sand', 'rock', 'water', 'sky', 'cloud', 'fire',
       'rust', 'paint', 'glass', 'ceramic', 'plastic', 'paper', 'cardboard'
     ];
+
+    // Map specific tags to more general categories
+    const generalTagMappings = {
+      brick: ['wall', 'masonry'],
+      stone: ['rock', 'material'],
+      wood: ['material', 'timber'],
+      metal: ['material'],
+      concrete: ['material'],
+      leather: ['material'],
+      fabric: ['material'],
+      grass: ['plant'],
+      dirt: ['ground'],
+      sand: ['ground'],
+      rock: ['stone'],
+      water: ['liquid'],
+      sky: ['outdoor'],
+      cloud: ['sky'],
+      fire: ['flame'],
+      rust: ['metal'],
+      paint: ['color'],
+      glass: ['material'],
+      ceramic: ['material'],
+      plastic: ['material'],
+      paper: ['material'],
+      cardboard: ['paper']
+    };
     
     // Manual corrections for common objects
     const specialObjects = {
@@ -2545,6 +2571,22 @@ async function generateImageTagsWithMobileNet(imageUrl) {
       if (!aIsTexture && bIsTexture) return 1;
       return 0;
     });
+
+    // Expand with general categories if fewer than five tags
+    if (processedTags.length < 5) {
+      for (const tag of [...processedTags]) {
+        const extras = generalTagMappings[tag];
+        if (extras) {
+          for (const extra of extras) {
+            if (processedTags.length >= 5) break;
+            if (!processedTags.includes(extra)) {
+              processedTags.push(extra);
+            }
+          }
+        }
+        if (processedTags.length >= 5) break;
+      }
+    }
 
     // Take up to the top 5 tags after processing
     const tags = processedTags.slice(0, 5).join(', ');

--- a/netlify/functions/cloudVision.js
+++ b/netlify/functions/cloudVision.js
@@ -41,6 +41,47 @@ exports.handler = async (event) => {
     const labels = (data.responses && data.responses[0].labelAnnotations) || [];
 
     const tagNames = labels.map(l => l.description.toLowerCase());
+
+    const generalTagMappings = {
+      brick: ['wall', 'masonry'],
+      stone: ['rock', 'material'],
+      wood: ['material', 'timber'],
+      metal: ['material'],
+      concrete: ['material'],
+      leather: ['material'],
+      fabric: ['material'],
+      grass: ['plant'],
+      dirt: ['ground'],
+      sand: ['ground'],
+      rock: ['stone'],
+      water: ['liquid'],
+      sky: ['outdoor'],
+      cloud: ['sky'],
+      fire: ['flame'],
+      rust: ['metal'],
+      paint: ['color'],
+      glass: ['material'],
+      ceramic: ['material'],
+      plastic: ['material'],
+      paper: ['material'],
+      cardboard: ['paper']
+    };
+
+    if (tagNames.length < 5) {
+      for (const tag of [...tagNames]) {
+        const extras = generalTagMappings[tag];
+        if (extras) {
+          for (const extra of extras) {
+            if (tagNames.length >= 5) break;
+            if (!tagNames.includes(extra)) {
+              tagNames.push(extra);
+            }
+          }
+        }
+        if (tagNames.length >= 5) break;
+      }
+    }
+
     const tags = tagNames.slice(0, 5).join(', ');
     const possibleObjects = labels.map(l => ({ name: l.description.toLowerCase(), confidence: l.score }));
 


### PR DESCRIPTION
## Summary
- pad missing tags with general categories in `generateImageTagsWithMobileNet`
- apply same fallback behavior in `cloudVision` function

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68405fbfdb84833081fa3bb12c887b1c