### PR TITLE
Fall back to heic2any when native canvas decode fails on upload

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,16 @@ with admin-only upload/tagging/organizing tools. Deployed on Netlify.
 - **`index.html`** — the entire frontend. One page, one big inline `<style>` block, one big
   inline `<script>` block. No build step, no bundler, no framework. Data flows straight from
   Firestore/Cloudinary into DOM manipulation.
+  - `compressImageIfNeeded()` recompresses oversized photos (JPEG quality reduction, not
+    resizing) client-side before upload, since Netlify Functions cap request bodies around 6MB —
+    an oversized upload that skips this gets rejected mid-stream by `upload.js`'s Busboy parser
+    ("Unexpected end of form"), not with a clean size-limit error. It decodes via `<img>`/canvas,
+    which can't read HEIC; `heic2any` (another CDN script, same pattern as the TF.js/MobileNet
+    ones below) is the fallback decoder when that native decode throws — this covers real
+    `.heic`/`.heif` files and also the case where iOS/Safari hands the page raw HEIC bytes under
+    a misleading `.jpeg` name/type. Don't remove the native-decode-first path even though
+    `heic2any` alone could handle everything — canvas is faster and avoids an unnecessary decode
+    round-trip for the common (non-HEIC) case.
 - **`netlify/functions/upload.js`** — receives multipart uploads (Busboy), pushes the file to
   Cloudinary, pre-generates 1200px/1920px derived sizes (`eager`) so the frontend's
   `cloudinaryDisplayUrl()` requests don't transform on first view.

--- a/index.html
+++ b/index.html
@@ -1183,7 +1183,8 @@
 
  <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@3.18.0"></script>
  <script src="https://cdn.jsdelivr.net/npm/@tensorflow-models/mobilenet@2.1.0"></script>
-  
+ <script src="https://cdn.jsdelivr.net/npm/heic2any@0.0.4/dist/heic2any.min.js"></script>
+
 </head>
 <body>
 
@@ -1641,6 +1642,27 @@ aboutModal.addEventListener("click", (e) => {
       return url.replace('/upload/', `/upload/${transform}/`);
     }
 
+    // Decode a browser-natively-supported image blob (JPEG/PNG/WebP/...) onto
+    // a canvas. Throws if the browser can't decode it (e.g. HEIC).
+    async function decodeToCanvas(blob) {
+      const objectUrl = URL.createObjectURL(blob);
+      try {
+        const img = new Image();
+        await new Promise((resolve, reject) => {
+          img.onload = resolve;
+          img.onerror = reject;
+          img.src = objectUrl;
+        });
+        const canvas = document.createElement('canvas');
+        canvas.width = img.naturalWidth;
+        canvas.height = img.naturalHeight;
+        canvas.getContext('2d').drawImage(img, 0, 0);
+        return canvas;
+      } finally {
+        URL.revokeObjectURL(objectUrl);
+      }
+    }
+
     // Netlify Functions reject request bodies over ~6MB (and base64-encode
     // binary uploads in transit, which inflates size by ~33% first). Re-encode
     // oversized images as JPEG, lowering quality (not pixel dimensions) until
@@ -1649,22 +1671,19 @@ aboutModal.addEventListener("click", (e) => {
       if (file.size <= maxBytes) return file;
 
       try {
-        const objectUrl = URL.createObjectURL(file);
-        const img = new Image();
+        let canvas;
         try {
-          await new Promise((resolve, reject) => {
-            img.onload = resolve;
-            img.onerror = reject;
-            img.src = objectUrl;
-          });
-        } finally {
-          URL.revokeObjectURL(objectUrl);
+          canvas = await decodeToCanvas(file);
+        } catch (decodeErr) {
+          // Most browsers can't decode HEIC/HEIF in an <img> tag - and iOS/Safari
+          // sometimes hands over raw HEIC bytes even when the file is named/typed
+          // as .jpeg. Decode it with heic2any (to PNG, so this stays lossless -
+          // the only lossy step is the JPEG re-encode below), then retry.
+          if (typeof heic2any === 'undefined') throw decodeErr;
+          const converted = await heic2any({ blob: file, toType: 'image/png' });
+          const pngBlob = Array.isArray(converted) ? converted[0] : converted;
+          canvas = await decodeToCanvas(pngBlob);
         }
-
-        const canvas = document.createElement('canvas');
-        canvas.width = img.naturalWidth;
-        canvas.height = img.naturalHeight;
-        canvas.getContext('2d').drawImage(img, 0, 0);
 
         let quality = 0.92;
         let blob = await new Promise(resolve => canvas.toBlob(resolve, 'image/jpeg', quality));


### PR DESCRIPTION
## Summary

- Uploads were failing with a 502 (`Unexpected end of form` from busboy, `netlify/functions/upload.js:96`) for photos like `IMG_2861.jpeg`. Root cause: the client-side safety net that recompresses oversized photos before upload (`compressImageIfNeeded()` in `index.html`, needed because Netlify Functions cap request bodies around 6MB) decodes via `<img>`/canvas — which most browsers can't do for HEIC. iOS/Safari sometimes hands the page raw HEIC bytes even when the `File` is named/typed `.jpeg`, so the decode silently failed, the original oversized file got uploaded anyway, and busboy choked mid-stream.
- Added `heic2any` (loaded the same way as the existing TensorFlow/MobileNet CDN scripts) as a fallback decoder: `decodeToCanvas()` tries the native `<img>` path first, and only on failure decodes through `heic2any` to PNG (lossless intermediate) before retrying — so the only lossy step remains the existing JPEG quality-reduction loop.
- No change to the existing behavior for non-HEIC oversized images, and small files still pass through untouched.

## Test plan

- [x] `npm test` (Jest, `tests/upload.test.js`) — unaffected, still green.
- [x] `node --check` on the extracted inline script — syntax valid.
- [x] Playwright smoke test against the served page (Firebase + `heic2any` stubbed, since their real CDNs are unreachable in the sandbox) covering:
  - a small file passes through `compressImageIfNeeded()` unchanged
  - an oversized natively-decodable PNG still compresses via the normal canvas path, without ever calling `heic2any` (no regression)
  - an oversized file with undecodable bytes under a misleading `.jpeg` name (the actual reported failure mode) correctly falls back to `heic2any` exactly once and produces a compressed JPEG under budget
- [ ] Manual verification with a real HEIC photo in a real browser (not possible from this sandbox — outbound access to `cdn.jsdelivr.net` is blocked here, so the real `heic2any` library never loads locally; the logic was verified via stubbing instead)

---
_Generated by [Claude Code](https://claude.ai/code/session_0137JdjdbCkDwqcxq74kg3iB)_