### PR TITLE
Always convert HEIC to JPEG before upload, regardless of file size

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,16 +8,22 @@ with admin-only upload/tagging/organizing tools. Deployed on Netlify.
 - **`index.html`** — the entire frontend. One page, one big inline `<style>` block, one big
   inline `<script>` block. No build step, no bundler, no framework. Data flows straight from
   Firestore/Cloudinary into DOM manipulation.
-  - `compressImageIfNeeded()` recompresses oversized photos (JPEG quality reduction, not
-    resizing) client-side before upload, since Netlify Functions cap request bodies around 6MB —
-    an oversized upload that skips this gets rejected mid-stream by `upload.js`'s Busboy parser
-    ("Unexpected end of form"), not with a clean size-limit error. It decodes via `<img>`/canvas,
-    which can't read HEIC; `heic2any` (another CDN script, same pattern as the TF.js/MobileNet
-    ones below) is the fallback decoder when that native decode throws — this covers real
-    `.heic`/`.heif` files and also the case where iOS/Safari hands the page raw HEIC bytes under
-    a misleading `.jpeg` name/type. Don't remove the native-decode-first path even though
-    `heic2any` alone could handle everything — canvas is faster and avoids an unnecessary decode
-    round-trip for the common (non-HEIC) case.
+  - `compressImageIfNeeded()` handles two separate problems that produce the identical symptom
+    (`upload.js`'s Busboy parser dies mid-stream with "Unexpected end of form", not a clean
+    error): (1) **any** HEIC/HEIF upload, regardless of size — confirmed by reproduction that
+    Netlify's function can't reliably accept raw HEIC bytes at all, so these always get decoded
+    and re-encoded as JPEG before upload, even a small 2MB HEIC that's nowhere near the size
+    limit; (2) oversized photos in general, since Netlify Functions cap request bodies around
+    6MB — those get the same JPEG re-encode, quality lowered (not resized) just enough to fit.
+    HEIC detection (`isHeicFile()`) sniffs the file's actual ISO-BMFF `ftyp` box instead of
+    trusting the name/MIME type, since both can lie (iOS/Safari sometimes hands the page raw
+    HEIC bytes under a misleading `.jpeg` name/type). Decoding goes through `<img>`/canvas first
+    (most browsers can't read HEIC this way, but it's faster and avoids an unnecessary decode
+    round-trip when it does work — e.g. Safari, which often can); `heic2any` (another CDN
+    script, same pattern as the TF.js/MobileNet ones below) is the fallback decoder when native
+    decode throws, converting to PNG first so the only lossy step stays the JPEG re-encode.
+    Don't gate the HEIC path behind the size check again — that was the original (wrong) design
+    and it's why the fix didn't work the first time.
 - **`netlify/functions/upload.js`** — receives multipart uploads (Busboy), pushes the file to
   Cloudinary, pre-generates 1200px/1920px derived sizes (`eager`) so the frontend's
   `cloudinaryDisplayUrl()` requests don't transform on first view.

--- a/index.html
+++ b/index.html
@@ -1663,22 +1663,41 @@ aboutModal.addEventListener("click", (e) => {
       }
     }
 
-    // Netlify Functions reject request bodies over ~6MB (and base64-encode
-    // binary uploads in transit, which inflates size by ~33% first). Re-encode
-    // oversized images as JPEG, lowering quality (not pixel dimensions) until
-    // they fit, so full-resolution photos from cameras/Unsplash don't 500.
+    // Sniffs the ISO-BMFF "ftyp" box at the start of the file to detect HEIC/HEIF
+    // content regardless of name or reported MIME type - both can lie (iOS/Safari
+    // sometimes hands the page raw HEIC bytes named/typed as .jpeg).
+    async function isHeicFile(file) {
+      if (/\.hei[cf]$/i.test(file.name) || /^image\/hei[cf]$/i.test(file.type)) return true;
+      try {
+        const bytes = new Uint8Array(await file.slice(4, 12).arrayBuffer());
+        if (bytes.length < 8) return false;
+        const boxType = String.fromCharCode(...bytes.subarray(0, 4));
+        const brand = String.fromCharCode(...bytes.subarray(4, 8));
+        const heicBrands = ['heic', 'heix', 'heim', 'heis', 'hevc', 'hevx', 'hevm', 'hevs', 'mif1', 'msf1'];
+        return boxType === 'ftyp' && heicBrands.includes(brand);
+      } catch {
+        return false;
+      }
+    }
+
+    // Netlify's upload function (busboy) reliably fails on raw HEIC/HEIF uploads
+    // regardless of size ("Unexpected end of form"), so those always get converted
+    // to JPEG below. Separately, Netlify Functions reject request bodies over
+    // ~6MB (base64-encoding binary uploads in transit inflates size by ~33% first),
+    // so anything still oversized after that gets re-encoded too, lowering quality
+    // (not pixel dimensions) until it fits, so full-resolution camera photos don't 500.
     async function compressImageIfNeeded(file, maxBytes = 4.5 * 1024 * 1024) {
-      if (file.size <= maxBytes) return file;
+      const isHeic = await isHeicFile(file);
+      if (!isHeic && file.size <= maxBytes) return file;
 
       try {
         let canvas;
         try {
           canvas = await decodeToCanvas(file);
         } catch (decodeErr) {
-          // Most browsers can't decode HEIC/HEIF in an <img> tag - and iOS/Safari
-          // sometimes hands over raw HEIC bytes even when the file is named/typed
-          // as .jpeg. Decode it with heic2any (to PNG, so this stays lossless -
-          // the only lossy step is the JPEG re-encode below), then retry.
+          // Most browsers can't decode HEIC/HEIF in an <img> tag. Decode it with
+          // heic2any instead (to PNG, so this stays lossless - the only lossy
+          // step is the JPEG re-encode below), then retry.
           if (typeof heic2any === 'undefined') throw decodeErr;
           const converted = await heic2any({ blob: file, toType: 'image/png' });
           const pngBlob = Array.isArray(converted) ? converted[0] : converted;
@@ -1692,7 +1711,12 @@ aboutModal.addEventListener("click", (e) => {
           blob = await new Promise(resolve => canvas.toBlob(resolve, 'image/jpeg', quality));
         }
 
-        if (!blob || blob.size >= file.size) return file;
+        // For non-HEIC files this re-encode is purely a size optimization, so
+        // skip it if it didn't actually help. HEIC always takes the converted
+        // blob - staying HEIC isn't an option - even if JPEG (which compresses
+        // worse) comes out larger.
+        if (!blob) return file;
+        if (!isHeic && blob.size >= file.size) return file;
 
         console.log(`Compressed ${file.name}: ${(file.size / 1024 / 1024).toFixed(1)}MB -> ${(blob.size / 1024 / 1024).toFixed(1)}MB (quality ${quality.toFixed(1)})`);
         const compressedName = file.name.replace(/\.[^./]+$/, '') + '.jpg';


### PR DESCRIPTION
## Summary

- Follow-up to #22, which turned out to be incomplete: after that merged, a real-world report showed a 2.3MB `IMG_2859.HEIC` (iPhone SE, 4032x3024) still failing upload with the identical busboy `Unexpected end of form` error, while JPEGs in the same batch succeeded.
- Root cause: `compressImageIfNeeded()` returned early for any file under the 4.5MB threshold (`if (file.size <= maxBytes) return file;`), so the `heic2any` fallback added in #22 was only ever reachable for **oversized** HEIC files. A small HEIC never entered that path at all, and its raw bytes got uploaded as-is — which fails regardless of size, since Netlify's function can't reliably accept raw HEIC uploads at all.
- Fix: added `isHeicFile()`, which sniffs the file's actual ISO-BMFF `ftyp` box (not just its name/MIME type, since both can lie — iOS/Safari sometimes hands the page raw HEIC bytes under a misleading `.jpeg` name). `compressImageIfNeeded()` now always routes HEIC/HEIF through the decode-and-re-encode-as-JPEG path, independent of size, and keeps the converted JPEG even if it comes out larger than the original (JPEG compresses worse than HEIC — staying HEIC isn't an option). Non-HEIC files keep the exact same size-gated behavior as before.
- Updated `CLAUDE.md` to describe the corrected behavior and flag the original size-gated design as the thing that made the first fix incomplete, so a future session doesn't reintroduce it.

## Test plan

- [x] `npm test` (Jest, `tests/upload.test.js`) — unaffected, still green.
- [x] `node --check` on the extracted inline script — syntax valid.
- [x] Playwright smoke test against the served page (Firebase + `heic2any` stubbed, since their real CDNs are unreachable in this sandbox) covering:
  - a small non-HEIC file passes through unchanged, untouched
  - a small (well under the size threshold) file named `IMG_2859.HEIC` — mirroring the exact reported failure — is now converted to JPEG despite being small
  - a small file with real HEIC magic bytes under a misleading `.jpeg` name is also detected (via the `ftyp` sniff) and converted
  - an oversized natively-decodable PNG still compresses via the normal canvas path without ever calling `heic2any` (no regression)
- [ ] Manual verification with a real HEIC photo in a real browser against the deploy preview for this PR (not possible from this sandbox — outbound access to `cdn.jsdelivr.net` is blocked here)

---
_Generated by [Claude Code](https://claude.ai/code/session_0137JdjdbCkDwqcxq74kg3iB)_