### PR TITLE
Align top search bar with the gallery instead of hardcoded side gaps

### DIFF
--- a/index.html
+++ b/index.html
@@ -860,10 +860,15 @@
 .top-search-bar {
   position: absolute;
   top: 15px;
-  left: calc(var(--sidebar-width) + 20px);
-  right: 170px; /* Leaves room for the About button */
+  /* Same horizontal insets as .main-content, so this bar lines up with the
+     gallery below it instead of looking randomly narrower. padding-right
+     (not a bigger `right`) reserves room for the About button, so it only
+     nudges where the search pill is centered without shrinking the box
+     itself out of alignment with the gallery. */
+  left: calc(var(--sidebar-width) + 0.8rem);
+  right: 0.8rem;
+  padding-right: 160px;
   z-index: 1000;
-  padding: 0;
   display: flex;
   justify-content: center;
 }
@@ -1096,7 +1101,7 @@
 @media (max-width: 640px) {
   :root { --sidebar-width: 200px; }
   .sidebar { padding: 0.6rem; }
-  .top-search-bar { left: calc(var(--sidebar-width) + 10px); right: 120px; top: 12px; }
+  .top-search-bar { left: calc(var(--sidebar-width) + 0.6rem); right: 0.6rem; padding-right: 104px; top: 12px; }
   .about-btn { top: 12px; right: 14px; width: 90px; padding: 8px 10px; font-size: 0.85rem; }
   #mainImageSearch { padding: 8px 12px; font-size: 0.85rem; }
   .main-content { padding-left: 0.6rem; padding-right: 0.6rem; padding-top: 70px; }
@@ -1109,7 +1114,7 @@
    keeps usable room next to it */
 @media (max-width: 420px) {
   :root { --sidebar-width: 140px; }
-  .top-search-bar { left: calc(var(--sidebar-width) + 8px); right: 96px; }
+  .top-search-bar { left: calc(var(--sidebar-width) + 0.6rem); right: 0.6rem; padding-right: 88px; }
   .about-btn { width: 78px; right: 10px; padding: 6px 8px; font-size: 0.78rem; }
 }
 


### PR DESCRIPTION
## Summary

- The top search bar's positioned box (`.top-search-bar`) used a fixed 20px left inset off the sidebar, but a fixed 170px right inset to clear the About button — two unrelated numbers that didn't match `.main-content`'s own `0.8rem` padding. Visually, the bar looked noticeably narrower than the gallery grid below it, especially on the right, where the mismatch was largest.
- Fix: `left`/`right` on `.top-search-bar` now match `.main-content`'s own insets exactly, so the bar's outer box lines up with the gallery. The About button's clearance is handled with `padding-right` on the same flex container instead of a bigger `right` offset — that only shifts where the search pill gets centered (`justify-content: center`), without moving the bar's actual boundary out of alignment with the gallery. Same idea applied to both responsive breakpoints (≤640px, ≤420px), matching each tier's own `.main-content` padding and `.about-btn` size.

## Test plan

- [x] `npm test` — unaffected, still green.
- [x] Playwright measurement pass (Firebase stubbed) at 1920/1440/1024/640/420px widths, comparing `.main-search-container`'s rendered edges against `.main-content`'s edges and `#aboutBtn`'s position:
  - left gap (gallery edge → search box) and right gap (search box → About button) are now numerically identical at every tested width (e.g. 155.0px / 155.0px at 1440px, 14.1px / 14.1px at 1024px, 10.5px / 10.5px at both 640px and 420px)
  - no overlap with the About button at any tested width
- [x] Visual screenshot check at 1440px and 1024px confirming the bar reads as centered/symmetric and aligned with the sidebar edge

---
_Generated by [Claude Code](https://claude.ai/code/session_0137JdjdbCkDwqcxq74kg3iB)_