### PR TITLE
Fix upload failures: unthrottled concurrency, unhandled busboy errors, and Safari's unreliable native HEIC decode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,25 +8,45 @@ with admin-only upload/tagging/organizing tools. Deployed on Netlify.
 - **`index.html`** — the entire frontend. One page, one big inline `<style>` block, one big
   inline `<script>` block. No build step, no bundler, no framework. Data flows straight from
   Firestore/Cloudinary into DOM manipulation.
-  - `compressImageIfNeeded()` handles two separate problems that produce the identical symptom
-    (`upload.js`'s Busboy parser dies mid-stream with "Unexpected end of form", not a clean
-    error): (1) **any** HEIC/HEIF upload, regardless of size — confirmed by reproduction that
-    Netlify's function can't reliably accept raw HEIC bytes at all, so these always get decoded
-    and re-encoded as JPEG before upload, even a small 2MB HEIC that's nowhere near the size
-    limit; (2) oversized photos in general, since Netlify Functions cap request bodies around
-    6MB — those get the same JPEG re-encode, quality lowered (not resized) just enough to fit.
-    HEIC detection (`isHeicFile()`) sniffs the file's actual ISO-BMFF `ftyp` box instead of
-    trusting the name/MIME type, since both can lie (iOS/Safari sometimes hands the page raw
-    HEIC bytes under a misleading `.jpeg` name/type). Decoding goes through `<img>`/canvas first
-    (most browsers can't read HEIC this way, but it's faster and avoids an unnecessary decode
-    round-trip when it does work — e.g. Safari, which often can); `heic2any` (another CDN
-    script, same pattern as the TF.js/MobileNet ones below) is the fallback decoder when native
-    decode throws, converting to PNG first so the only lossy step stays the JPEG re-encode.
-    Don't gate the HEIC path behind the size check again — that was the original (wrong) design
-    and it's why the fix didn't work the first time.
+  - Uploads failing with a 502 from `upload.js` — Busboy's "Unexpected end of form" — has turned
+    out to have **multiple independent causes that produce the exact same client-visible error**.
+    A report of "still broken" after fixing one of these does NOT mean that fix was wrong; check
+    which mechanism actually applies (file format? file size? uploaded alongside others?) before
+    assuming the same cause needs revisiting again:
+    1. **Any HEIC/HEIF upload, regardless of size** — Netlify's function can't reliably accept
+       raw HEIC bytes at all. `compressImageIfNeeded()` always decodes and re-encodes HEIC/HEIF
+       as JPEG before upload, even a small 2MB HEIC nowhere near the size limit — gating this
+       behind a size check (the original design) is why the first attempt at this fix didn't
+       work. Detection (`isHeicFile()`) sniffs the file's actual ISO-BMFF `ftyp` box instead of
+       trusting name/MIME type, since both can lie (iOS/Safari sometimes hands the page raw HEIC
+       bytes under a misleading `.jpeg` name/type). Decoding tries `<img>`/canvas first (most
+       browsers can't read HEIC this way, but it's faster and works in some, e.g. Safari);
+       `heic2any` (CDN script, same pattern as TF.js/MobileNet below) is the fallback when native
+       decode throws, converting to PNG first so the JPEG re-encode stays the only lossy step.
+    2. **Oversized photos in general, any format** — Netlify Functions cap request bodies around
+       6MB, so anything still too big after HEIC handling gets the same JPEG re-encode, quality
+       lowered (not resized) just enough to fit.
+    3. **Multiple simultaneous uploads competing for upload bandwidth.** The upload-confirm
+       handler used to fire every file's `processUpload()` in an unawaited loop — fully parallel,
+       no limit. Several multi-MB uploads racing over the same (often limited) uplink can keep
+       any single one from finishing before Netlify's function times out, and Busboy reports
+       that identically as "Unexpected end of form". This reproduced even for a genuinely native
+       JPEG uploaded alongside several siblings — which is what revealed the problem wasn't
+       purely about HEIC. Uploads now run sequentially (`await`ed in a loop) instead of all at
+       once; DOM upload-dock items are still all created up front so the queue is visible
+       immediately.
 - **`netlify/functions/upload.js`** — receives multipart uploads (Busboy), pushes the file to
   Cloudinary, pre-generates 1200px/1920px derived sizes (`eager`) so the frontend's
   `cloudinaryDisplayUrl()` requests don't transform on first view.
+  - Busboy's `Multipart` stream emits `'error'` in **two separate places** for one underlying
+    parse failure: once on the `busboy` instance itself, and independently on the per-file
+    stream handed to the `'file'` event (its `_destroy` explicitly destroys that inner stream
+    with the same error). Both need a listener — an EventEmitter that emits `'error'` with zero
+    listeners crashes the process — which is why a truncated upload used to take down the whole
+    Lambda invocation (502 with a raw internal stack trace) instead of returning a clean,
+    retryable error. Confirmed by reproduction in a Jest test: listening only on the outer
+    `busboy` still crashed with the identical trace, because the *inner* file stream's error was
+    the one actually unhandled.
 - **`netlify/functions/cloudVision.js`** — calls Google Cloud Vision (`LABEL_DETECTION`) to tag
   an uploaded image; falls back to client-side MobileNet (TensorFlow.js, loaded from a CDN) if
   Vision fails or the key is missing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,14 +19,26 @@ with admin-only upload/tagging/organizing tools. Deployed on Netlify.
        behind a size check (the original design) is why the first attempt at this fix didn't
        work. Detection (`isHeicFile()`) sniffs the file's actual ISO-BMFF `ftyp` box instead of
        trusting name/MIME type, since both can lie (iOS/Safari sometimes hands the page raw HEIC
-       bytes under a misleading `.jpeg` name/type). Decoding tries `<img>`/canvas first (most
-       browsers can't read HEIC this way, but it's faster and works in some, e.g. Safari);
-       `heic2any` (CDN script, same pattern as TF.js/MobileNet below) is the fallback when native
-       decode throws, converting to PNG first so the JPEG re-encode stays the only lossy step.
-    2. **Oversized photos in general, any format** — Netlify Functions cap request bodies around
+       bytes under a misleading `.jpeg` name/type, confirmed with a real iPhone SE photo: Finder
+       showed `.HEIC`, the browser's `File.name` showed `.jpeg`). `heic2any` (CDN script, same
+       pattern as TF.js/MobileNet below) does the actual decoding, to PNG first so the JPEG
+       re-encode stays the only lossy step.
+    2. **Don't try native `<img>`/canvas decode before `heic2any` for files detected as HEIC**,
+       even though it works for every other format and seems like a reasonable fast path (this
+       was the original design of step 1 above, and was itself a bug that needed a follow-up
+       fix). Chrome/Firefox reliably throw on HEIC there, but Safari's support is inconsistent
+       specifically for `blob:` URLs (i.e. exactly what `URL.createObjectURL(file)` produces) —
+       confirmed by reports that a given HEIC upload failed on Safari but succeeded on Chrome
+       from the same machine: Safari's `<img>` decode can fire `onload` with no error but a 0x0
+       image instead of throwing, which silently produced an empty canvas and uploaded the
+       original raw HEIC file instead of falling back to `heic2any`. `decodeToCanvas()` now also
+       throws if `naturalWidth`/`naturalHeight` come back 0 after `onload`, as a general
+       safety net, but HEIC specifically skips the native path entirely rather than relying on
+       that check to catch it after the fact.
+    3. **Oversized photos in general, any format** — Netlify Functions cap request bodies around
        6MB, so anything still too big after HEIC handling gets the same JPEG re-encode, quality
        lowered (not resized) just enough to fit.
-    3. **Multiple simultaneous uploads competing for upload bandwidth.** The upload-confirm
+    4. **Multiple simultaneous uploads competing for upload bandwidth.** The upload-confirm
        handler used to fire every file's `processUpload()` in an unawaited loop — fully parallel,
        no limit. Several multi-MB uploads racing over the same (often limited) uplink can keep
        any single one from finishing before Netlify's function times out, and Busboy reports

--- a/index.html
+++ b/index.html
@@ -1648,7 +1648,11 @@ aboutModal.addEventListener("click", (e) => {
     }
 
     // Decode a browser-natively-supported image blob (JPEG/PNG/WebP/...) onto
-    // a canvas. Throws if the browser can't decode it (e.g. HEIC).
+    // a canvas. Throws if the browser can't decode it (e.g. HEIC) - including
+    // when it *claims* to (Safari's native HEIC support is inconsistent for
+    // blob: URLs specifically: onload can fire with no error but a 0x0
+    // image, which would otherwise silently produce an empty canvas instead
+    // of surfacing a decode failure).
     async function decodeToCanvas(blob) {
       const objectUrl = URL.createObjectURL(blob);
       try {
@@ -1658,6 +1662,9 @@ aboutModal.addEventListener("click", (e) => {
           img.onerror = reject;
           img.src = objectUrl;
         });
+        if (!img.naturalWidth || !img.naturalHeight) {
+          throw new Error('Decoded image has no dimensions');
+        }
         const canvas = document.createElement('canvas');
         canvas.width = img.naturalWidth;
         canvas.height = img.naturalHeight;
@@ -1697,16 +1704,18 @@ aboutModal.addEventListener("click", (e) => {
 
       try {
         let canvas;
-        try {
-          canvas = await decodeToCanvas(file);
-        } catch (decodeErr) {
-          // Most browsers can't decode HEIC/HEIF in an <img> tag. Decode it with
-          // heic2any instead (to PNG, so this stays lossless - the only lossy
-          // step is the JPEG re-encode below), then retry.
-          if (typeof heic2any === 'undefined') throw decodeErr;
+        if (isHeic) {
+          // Don't even try the native <img> path for HEIC: most browsers can't
+          // decode it there at all (reliably throws), but Safari's support is
+          // inconsistent enough - it can silently "succeed" with a broken
+          // image for some HEIC files specifically as blob: URLs - that
+          // trusting it is worse than just always paying for heic2any.
+          if (typeof heic2any === 'undefined') throw new Error('heic2any not loaded');
           const converted = await heic2any({ blob: file, toType: 'image/png' });
           const pngBlob = Array.isArray(converted) ? converted[0] : converted;
           canvas = await decodeToCanvas(pngBlob);
+        } else {
+          canvas = await decodeToCanvas(file);
         }
 
         let quality = 0.92;

--- a/index.html
+++ b/index.html
@@ -2901,13 +2901,12 @@ function closeEnlargeModal() {
     return;
   }
   
-  // Process each file
+  // Create all the upload dock items up front, so the whole queue is visible
+  // immediately even though the uploads themselves run one at a time below.
   for (let i = 0; i < files.length; i++) {
     const file = files[i];
-    
-    // Create upload item in the dock
     const uploadItemId = `upload-${uploadBatchId}-${i}`;
-    
+
     const uploadItem = document.createElement("div");
     uploadItem.classList.add("upload-dock-item");
     uploadItem.id = uploadItemId;
@@ -2921,11 +2920,18 @@ function closeEnlargeModal() {
         <div class="upload-dock-progress-fill" id="progress-${uploadItemId}" style="width: 0%"></div>
       </div>
     `;
-    
+
     uploadDockContent.appendChild(uploadItem);
-    
-    // Actually call the processUpload function with the file
-    processUpload(file, folderValue, keywords, uploadItemId);
+  }
+
+  // Upload one file at a time, not all at once: several multi-MB uploads
+  // competing for the same (often limited) upload bandwidth can keep any
+  // single one of them from finishing before Netlify's function times out -
+  // busboy reports that as "Unexpected end of form" on whichever file lost
+  // the race, not as an error tied to that file's content or format.
+  for (let i = 0; i < files.length; i++) {
+    const uploadItemId = `upload-${uploadBatchId}-${i}`;
+    await processUpload(files[i], folderValue, keywords, uploadItemId);
   }
 });
 

--- a/netlify/functions/upload.js
+++ b/netlify/functions/upload.js
@@ -34,6 +34,15 @@ const handler = (event, context, callback) => {
   let fileBuffer = null;
   let fileName = '';
 
+  // Busboy (and the Cloudinary callback below) can each try to respond -
+  // make sure only the first one actually calls back to Lambda.
+  let responded = false;
+  const respond = (response) => {
+    if (responded) return;
+    responded = true;
+    callback(null, response);
+  };
+
   // When Busboy finds a file
   busboy.on('file', (fieldname, file, info) => {
     fileName = info.filename;
@@ -43,6 +52,26 @@ const handler = (event, context, callback) => {
     });
     file.on('end', () => {
       fileBuffer = Buffer.concat(chunks);
+    });
+    // A parse failure below destroys this file stream with the same error -
+    // that's a second, separate EventEmitter 'error' with no listener of its
+    // own, which crashes the invocation even though the 'error' handler below
+    // already handles the overall parse failure.
+    file.on('error', () => {});
+  });
+
+  // A request body that got cut off in transit (e.g. several uploads
+  // competing for the same limited upload bandwidth, one of them not
+  // finishing before the gateway's timeout) fails here with an "Unexpected
+  // end of form" error rather than through the normal 'finish' event. With
+  // no listener, that error is unhandled and crashes the whole invocation
+  // (a 502 with a raw internal stack trace) instead of a clean, retryable
+  // response.
+  busboy.on('error', (err) => {
+    console.error('Busboy parse error:', err);
+    respond({
+      statusCode: 400,
+      body: JSON.stringify({ error: 'Upload did not complete - please try again', details: err.message }),
     });
   });
 
@@ -69,13 +98,13 @@ const handler = (event, context, callback) => {
       (error, result) => {
         if (error) {
           console.error('Cloudinary Upload Error:', error);
-          return callback(null, {
+          return respond({
             statusCode: 500,
             body: JSON.stringify({ error: 'Upload failed', details: error }),
           });
         }
         // Return the secure URL
-        return callback(null, {
+        return respond({
           statusCode: 200,
           body: JSON.stringify({ url: result.secure_url }),
         });
@@ -85,7 +114,7 @@ const handler = (event, context, callback) => {
     if (fileBuffer) {
       uploadStream.end(fileBuffer);
     } else {
-      return callback(null, {
+      return respond({
         statusCode: 400,
         body: JSON.stringify({ error: 'No file data received' }),
       });

--- a/tests/upload.test.js
+++ b/tests/upload.test.js
@@ -57,4 +57,24 @@ describe('upload handler', () => {
     expect(result.statusCode).toBe(200);
     expect(JSON.parse(result.body)).toEqual({ url: `http://example.com/${receivedOptions.public_id}` });
   });
+
+  test('returns a clean 400 for a truncated multipart body instead of throwing', async () => {
+    const boundary = '----testboundary';
+    // Missing the closing "--boundary--" - simulates a request that got cut
+    // off in transit before finishing.
+    const body = `--${boundary}\r\n` +
+      `Content-Disposition: form-data; name="file"; filename="test.txt"\r\n` +
+      'Content-Type: text/plain\r\n\r\n' +
+      'hello world\r\n';
+
+    const result = await runHandler({
+      httpMethod: 'POST',
+      headers: { 'content-type': `multipart/form-data; boundary=${boundary}` },
+      body,
+      isBase64Encoded: false,
+    });
+
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body).error).toMatch(/upload did not complete/i);
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to #22/#23. Two distinct bugs found through testing on the deploy preview:

**1. Concurrency + unhandled busboy errors** (original scope of this PR):
- The upload-confirm handler fired every selected file's `processUpload()` in a bare `for` loop with no `await` — fully unthrottled parallel uploads. Several multi-MB uploads racing over the same (often limited) upload bandwidth can keep any single one of them from finishing its request body before Netlify's function times out; Busboy reports that as `Unexpected end of form` regardless of that file's format or size. Uploads now run sequentially; the upload-dock DOM items are still all created up front so the whole queue is visible immediately.
- `netlify/functions/upload.js`: Busboy's `Multipart` stream emits `'error'` in two separate places for one parse failure — once on the `busboy` instance, and independently on the per-file stream (destroyed with the same error). Only the outer one was handled; the inner, unlistened one is what was actually crashing the Lambda invocation into a raw-stack-trace 502. Added a listener for both, plus a `responded` guard.

**2. Safari can't be trusted to decode HEIC natively (found via real-device testing after the above)**:
- A real iPhone SE HEIC photo (confirmed via Finder: genuinely `.HEIC`, 2.2MB) still failed on Safari with the exact same error after the fixes above, while the identical file succeeded on Chrome on the same machine. Root cause: Chrome/Firefox reliably *throw* when `<img>` can't decode HEIC, correctly triggering the existing `heic2any` fallback from #22 — but Safari's native HEIC support is inconsistent specifically for `blob:` URLs (exactly what `URL.createObjectURL(file)` produces): `onload` can fire with **no error but a 0x0 image**, which silently produced an empty canvas and uploaded the original raw HEIC file instead of ever calling `heic2any`.
- Fix: HEIC-detected files now skip the native `<img>`/canvas decode path entirely and always go through `heic2any`. `decodeToCanvas()` also now throws if the decoded image comes back with zero dimensions, as a general safety net for any other caller.
- This is now documented in `CLAUDE.md` as its own numbered cause, since it's a genuinely distinct failure mode from the other three already listed there.

## Test plan

- [x] `npm test` — including the new regression test simulating a truncated multipart body (no closing boundary), asserting a clean `400` instead of an unhandled crash.
- [x] `node --check` on the extracted inline script.
- [x] Playwright: confirmed a HEIC-signed file whose bytes are actually natively-decodable (standing in for Safari's "succeeds anyway" case) still routes through `heic2any`, and that a 0-byte blob passed to `decodeToCanvas()` now throws instead of yielding an empty canvas. Also re-confirmed no regression on normal oversized-PNG compression (no `heic2any` call) and on small-file passthrough.
- [x] Real-device verification on the deploy preview: reporter confirmed the original failing HEIC file now uploads successfully on Chrome; Safari-specific fix above is a direct response to their follow-up report that it still failed there (not yet re-confirmed on Safari after this commit).