### PR TITLE
Add admin Edit Tags mode for selecting and re-tagging images

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,38 +39,37 @@ with admin-only upload/tagging/organizing tools. Deployed on Netlify.
   - "Submit" (2026-07-30, `submitReferenceBtn`/`submitReferenceModal`) is deliberately **not**
     admin-gated — it's the public-facing counterpart to the admin tools above, for visitors who
     want to send the site owner a link (e.g. a Drive folder) or images without needing an email
-    address. It writes to its own `submissions` Firestore collection (`link`, `imageUrls`, `note`,
-    `timestamp`) rather than `images`/`folders`, so submissions never appear in the gallery on
-    their own — reviewing them and actually adding anything to the gallery is a manual step (via
-    Firebase console today; there's no admin review UI for this collection yet). Image uploads
-    reuse `compressImageIfNeeded()`/`uploadImage()` as-is (same Cloudinary path as admin uploads),
+    address. It's **email-only, on purpose**: submitting fires `sendSubmissionEmailNotification()`,
+    which posts straight to FormSubmit's AJAX relay (`https://formsubmit.co/ajax/...`) addressed
+    to **isakovicadrien@gmail.com**, and that's it — nothing is written to Firestore, nothing
+    touches `images`/`folders`, and there is deliberately no second place (like a Firestore
+    collection) to go check for these. The site owner explicitly asked for exactly this: receive
+    submissions by email, then decide by hand whether to add anything through the existing Add
+    Image flow. **Don't reintroduce a Firestore write for submissions** without a fresh explicit
+    request - that was tried once in this same feature and rejected specifically because it created
+    a second, easy-to-forget-about place submissions could land invisibly. Because there's no
+    backend of our own here, a failed/unreachable relay call is a hard, user-visible error (not a
+    silently-swallowed one) — email is the *only* delivery path, so the submitter needs to know if
+    it didn't go through. **isakovicadrien@gmail.com must click the one-time "activate this inbox"
+    email FormSubmit sends on the very first real submission**, or every submission after that will
+    keep failing loudly until that's done. The destination address is a plain string in the
+    client-side fetch call, so it's visible in the browser's network tab to anyone who looks, even
+    though it's never printed anywhere in the page's own UI — an inherent trade-off of doing this
+    with no backend of our own, not an oversight. If the address ever needs to change, it's a
+    single string to edit in `index.html`, not an env var. Image uploads reuse
+    `compressImageIfNeeded()`/`uploadImage()` as-is (same Cloudinary path as admin uploads),
     sequentially rather than in parallel, for the same reason upload.js's `Unexpected end of form`
-    fix made the admin upload dock sequential (see above).
-  - Each submission also fires a best-effort email notification (2026-07-30,
-    `sendSubmissionEmailNotification()`) to **isakovicadrien@gmail.com** via FormSubmit's AJAX
-    relay (`https://formsubmit.co/ajax/...`) — chosen specifically to avoid standing up any new
-    backend/API key for this. **That inbox must click the one-time "activate this inbox" email
-    FormSubmit sends on the very first real submission**, or silently no notifications will ever
-    arrive (the Firestore `submissions` doc still gets written regardless — that's the durable
-    record; the email is just a heads-up, and its failure is caught and logged, not surfaced to
-    the submitter). The destination address is a plain string in the client-side fetch call, so
-    it's visible in the browser's network tab to anyone who looks, even though it's never printed
-    anywhere in the page's own UI — that's an inherent trade-off of doing this with no backend of
-    our own, not an oversight. If this address ever needs to change, it's a single string to edit
-    in `index.html`, not an env var.
+    fix made the admin upload dock sequential (see above) — so the images themselves do land in
+    Cloudinary (their URLs are what gets emailed), just not in Firestore/the gallery.
 - **`netlify/functions/upload.js`** — receives multipart uploads (Busboy), pushes the file to
   Cloudinary, pre-generates 1200px/1920px derived sizes (`eager`) so the frontend's
   `cloudinaryDisplayUrl()` requests don't transform on first view.
 - **`netlify/functions/cloudVision.js`** — calls Google Cloud Vision (`LABEL_DETECTION`) to tag
   an uploaded image; falls back to client-side MobileNet (TensorFlow.js, loaded from a CDN) if
   Vision fails or the key is missing.
-- **Firestore** — three collections: `folders` (name, parent), `images` (url, folder, keywords,
-  filename, timestamp), and `submissions` (link, imageUrls, note, timestamp — public visitor
-  submissions via the "Submit" button, not surfaced anywhere in the UI, reviewed manually). No
-  auth backing any of this — see "Admin access" below. **If submissions aren't showing up in
-  Firestore, check the security rules allow writes to `submissions` specifically** — it's a
-  newer collection than `folders`/`images` and may not be covered by existing rules even if those
-  two already allow open writes.
+- **Firestore** — two collections: `folders` (name, parent) and `images` (url, folder, keywords,
+  filename, timestamp). No auth backing this — see "Admin access" below. Public "Submit"
+  submissions deliberately do **not** go through Firestore at all — see the "Submit" note above.
 - **Cloudinary** — actual image storage/hosting + on-the-fly resizing via URL transforms.
 
 ## Environment variables (Netlify)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,18 @@ with admin-only upload/tagging/organizing tools. Deployed on Netlify.
     decode throws, converting to PNG first so the only lossy step stays the JPEG re-encode.
     Don't gate the HEIC path behind the size check again — that was the original (wrong) design
     and it's why the fix didn't work the first time.
+  - Delete Images, Move Images, and Edit Tags (2026-07-30) are three separate select-then-act
+    modes (`isDeleteMode`/`isMoveMode`/`isTagEditMode`, each with its own `.image-container`
+    overlay class and floating controls bar) that all read clicks on the same gallery thumbnails.
+    They're mutually exclusive by construction — turning one on turns the other two off — because
+    two active at once would double-fire click handlers on the same image. If you add a fourth
+    bulk-select mode, wire it into that same turn-off-the-others chain rather than assuming it's
+    the only one active. Also: the enlarge/lightbox modal's click handler reads tags from the live
+    `data-keywords` attribute (`container.getAttribute('data-keywords')`), not the `keywords`
+    function parameter closed over when the thumbnail was created — that parameter goes stale the
+    moment Edit Tags updates the attribute, and reintroducing a closure read there would make tag
+    edits silently not show up in the lightbox (same silent-failure shape as the delete/move bug
+    fixed earlier).
 - **`netlify/functions/upload.js`** — receives multipart uploads (Busboy), pushes the file to
   Cloudinary, pre-generates 1200px/1920px derived sizes (`eager`) so the frontend's
   `cloudinaryDisplayUrl()` requests don't transform on first view.
@@ -49,7 +61,7 @@ with admin-only upload/tagging/organizing tools. Deployed on Netlify.
 
 There's no real auth. "ADMIN ACCESS" opens a `UI Preferences` modal (`#userPreference` field,
 `#applyPreferenceBtn`) that reveals the edit buttons (add/move/delete/rename folders+images,
-find duplicates) on Apply.
+edit image tags, find duplicates) on Apply.
 
 **2026-07-28: the password check was intentionally removed, at the site owner's explicit
 request ("no password for admin for now").** `applyPreferenceBtn`'s click handler now grants

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,14 +36,29 @@ with admin-only upload/tagging/organizing tools. Deployed on Netlify.
     moment Edit Tags updates the attribute, and reintroducing a closure read there would make tag
     edits silently not show up in the lightbox (same silent-failure shape as the delete/move bug
     fixed earlier).
+  - "Submit" (2026-07-30, `submitReferenceBtn`/`submitReferenceModal`) is deliberately **not**
+    admin-gated — it's the public-facing counterpart to the admin tools above, for visitors who
+    want to send the site owner a link (e.g. a Drive folder) or images without needing an email
+    address. It writes to its own `submissions` Firestore collection (`link`, `imageUrls`, `note`,
+    `timestamp`) rather than `images`/`folders`, so submissions never appear in the gallery on
+    their own — reviewing them and actually adding anything to the gallery is a manual step (via
+    Firebase console today; there's no admin review UI for this collection yet). Image uploads
+    reuse `compressImageIfNeeded()`/`uploadImage()` as-is (same Cloudinary path as admin uploads),
+    sequentially rather than in parallel, for the same reason upload.js's `Unexpected end of form`
+    fix made the admin upload dock sequential (see above).
 - **`netlify/functions/upload.js`** — receives multipart uploads (Busboy), pushes the file to
   Cloudinary, pre-generates 1200px/1920px derived sizes (`eager`) so the frontend's
   `cloudinaryDisplayUrl()` requests don't transform on first view.
 - **`netlify/functions/cloudVision.js`** — calls Google Cloud Vision (`LABEL_DETECTION`) to tag
   an uploaded image; falls back to client-side MobileNet (TensorFlow.js, loaded from a CDN) if
   Vision fails or the key is missing.
-- **Firestore** — two collections: `folders` (name, parent) and `images` (url, folder, keywords,
-  filename, timestamp). No auth backing this — see "Admin access" below.
+- **Firestore** — three collections: `folders` (name, parent), `images` (url, folder, keywords,
+  filename, timestamp), and `submissions` (link, imageUrls, note, timestamp — public visitor
+  submissions via the "Submit" button, not surfaced anywhere in the UI, reviewed manually). No
+  auth backing any of this — see "Admin access" below. **If submissions aren't showing up in
+  Firestore, check the security rules allow writes to `submissions` specifically** — it's a
+  newer collection than `folders`/`images` and may not be covered by existing rules even if those
+  two already allow open writes.
 - **Cloudinary** — actual image storage/hosting + on-the-fly resizing via URL transforms.
 
 ## Environment variables (Netlify)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,22 +8,28 @@ with admin-only upload/tagging/organizing tools. Deployed on Netlify.
 - **`index.html`** — the entire frontend. One page, one big inline `<style>` block, one big
   inline `<script>` block. No build step, no bundler, no framework. Data flows straight from
   Firestore/Cloudinary into DOM manipulation.
-  - `compressImageIfNeeded()` handles two separate problems that produce the identical symptom
-    (`upload.js`'s Busboy parser dies mid-stream with "Unexpected end of form", not a clean
-    error): (1) **any** HEIC/HEIF upload, regardless of size — confirmed by reproduction that
-    Netlify's function can't reliably accept raw HEIC bytes at all, so these always get decoded
-    and re-encoded as JPEG before upload, even a small 2MB HEIC that's nowhere near the size
-    limit; (2) oversized photos in general, since Netlify Functions cap request bodies around
-    6MB — those get the same JPEG re-encode, quality lowered (not resized) just enough to fit.
-    HEIC detection (`isHeicFile()`) sniffs the file's actual ISO-BMFF `ftyp` box instead of
-    trusting the name/MIME type, since both can lie (iOS/Safari sometimes hands the page raw
-    HEIC bytes under a misleading `.jpeg` name/type). Decoding goes through `<img>`/canvas first
-    (most browsers can't read HEIC this way, but it's faster and avoids an unnecessary decode
-    round-trip when it does work — e.g. Safari, which often can); `heic2any` (another CDN
-    script, same pattern as the TF.js/MobileNet ones below) is the fallback decoder when native
-    decode throws, converting to PNG first so the only lossy step stays the JPEG re-encode.
-    Don't gate the HEIC path behind the size check again — that was the original (wrong) design
-    and it's why the fix didn't work the first time.
+  - `compressImageIfNeeded()` (2026-07-30: retargeted to 1.5MB, was ~4.5MB) handles two separate
+    problems: (1) **any** HEIC/HEIF upload, regardless of size — confirmed by reproduction that
+    Netlify's function can't reliably accept raw HEIC bytes at all (Busboy dies mid-stream with
+    "Unexpected end of form"), so these always get decoded and re-encoded as JPEG before upload,
+    even a small 2MB HEIC that's nowhere near the size limit; (2) **every** upload over 1.5MB,
+    period — this is now a deliberate blanket "keep uploads small" policy (the owner's request),
+    not just dodging Netlify's ~6MB request body cap the way it originally was. HEIC detection
+    (`isHeicFile()`) sniffs the file's actual ISO-BMFF `ftyp` box instead of trusting the name/MIME
+    type, since both can lie (iOS/Safari sometimes hands the page raw HEIC bytes under a misleading
+    `.jpeg` name/type). Decoding goes through `<img>`/canvas first (most browsers can't read HEIC
+    this way, but it's faster and avoids an unnecessary decode round-trip when it does work — e.g.
+    Safari, which often can); `heic2any` (another CDN script, same pattern as the TF.js/MobileNet
+    ones below) is the fallback decoder when native decode throws, converting to PNG first so the
+    only lossy step stays the JPEG re-encode. Don't gate the HEIC path behind the size check again
+    — that was the original (wrong) design and it's why the fix didn't work the first time.
+    `encodeCanvasUnderSize()` does the actual fitting: quality drops first (0.92 down to a 0.5
+    floor) at the image's original resolution, and only once quality alone can't hit 1.5MB does it
+    actually shrink the canvas (in 15%-per-step passes, down to an 800px floor on the shorter
+    side) and restart the quality sweep at the smaller size. This ordering is the point — a huge
+    photo stepped down to a still-generous resolution at good quality looks better than the same
+    photo kept at full resolution and crushed to a very low quality, and most of that resolution is
+    invisible anyway once Cloudinary serves it back down to 1200/1920px for display.
   - Delete Images, Move Images, and Edit Tags (2026-07-30) are three separate select-then-act
     modes (`isDeleteMode`/`isMoveMode`/`isTagEditMode`, each with its own `.image-container`
     overlay class and floating controls bar) that all read clicks on the same gallery thumbnails.
@@ -35,7 +41,19 @@ with admin-only upload/tagging/organizing tools. Deployed on Netlify.
     function parameter closed over when the thumbnail was created — that parameter goes stale the
     moment Edit Tags updates the attribute, and reintroducing a closure read there would make tag
     edits silently not show up in the lightbox (same silent-failure shape as the delete/move bug
-    fixed earlier).
+    fixed earlier). `enlargeImage()` also takes the `.image-container` itself as a 4th argument now
+    (2026-07-30), stashed in module-level `currentEnlargedContainer` purely so the lightbox's
+    prev/next arrows (click or ←/→ keys) know where they are in the currently-visible gallery
+    order (`getVisibleGalleryContainers()` — same filtered/sorted list the grid itself shows) and
+    can wrap to the next/previous one. Any other future caller of `enlargeImage()` should pass the
+    container too, or prev/next will silently no-op for that entry point. Edit Tags' shared field
+    (2026-07-30) has two modes tracked by `editTagsAllMatched`, set when the modal opens: if every
+    selected image already had identical tags, Save **replaces** them (unchanged from the original
+    design); if they differed, Save instead **adds** whatever was typed to each image's own
+    existing tags via `mergeTagStrings()` (comma-list union, case-insensitive dedupe) - each image
+    keeps its individual previous tags rather than having them clobbered by one value that was
+    never even shown for that image. Don't collapse this back to always-replace; that's the exact
+    behavior that was reported as a problem.
   - "Submit" (2026-07-30, `submitReferenceBtn`/`submitReferenceModal`) is deliberately **not**
     admin-gated — it's the public-facing counterpart to the admin tools above, for visitors who
     want to send the site owner a link (e.g. a Drive folder) or images without needing an email
@@ -66,7 +84,16 @@ with admin-only upload/tagging/organizing tools. Deployed on Netlify.
     `completeUpload()` makes after a normal admin upload finishes. "Dismiss" hard-deletes the
     submission's Firestore doc once it's been dealt with (whether 0, some, or all of its images
     got added) — there's no "mark as reviewed" limbo state, so don't add one without a reason;
-    the point was to keep the queue short, not to grow a permanent log.
+    the point was to keep the queue short, not to grow a permanent log. **`.sidebar` has a higher
+    z-index (1100) than `.modal-backdrop` (999)** - a pre-existing mismatch, not introduced here,
+    that only bites when a modal is wide enough to visually extend under the sidebar's ~270px
+    width, at which point that overlapping strip's clicks land on whatever sidebar button is
+    there instead of the modal content underneath (found the hard way: widening this panel to
+    980px did exactly that to its own Dismiss button on a 1400px-wide test viewport). Fixed here
+    by keeping this panel's `max-width` at 840px instead of properly reordering the z-index stack
+    site-wide - if a future modal needs to be wider than roughly `viewport - 540px`, the real fix
+    is raising `.modal-backdrop` above 1100 (and re-checking `.about-btn`/`.submit-reference-btn`,
+    which sit at 1200 for the same reason), not just shrinking that modal too.
 - **`netlify/functions/upload.js`** — receives multipart uploads (Busboy), pushes the file to
   Cloudinary, pre-generates 1200px/1920px derived sizes (`eager`) so the frontend's
   `cloudinaryDisplayUrl()` requests don't transform on first view.
@@ -98,12 +125,16 @@ with admin-only upload/tagging/organizing tools. Deployed on Netlify.
 
 ## Admin access
 
-**2026-07-30: real auth, replacing the no-password gate below.** "ADMIN ACCESS" now opens an
-`#adminLoginModal` (email + password) that calls Firebase Auth's
+**2026-07-30: real auth, replacing the no-password gate below.** "Admin Log In" (the button was
+renamed from "ADMIN ACCESS" the same day, and becomes "SIGN OUT" once signed in) opens an
+`#adminLoginModal` (email + password, Enter submits from either field) that calls Firebase Auth's
 `signInWithEmailAndPassword()`. There is exactly **one** admin account, created manually in
 Firebase Console → Authentication → Users, using **isakovicadrien@gmail.com** (the Email/Password
 sign-in method must be enabled first, under Authentication → Sign-in method — neither step can be
-done from a coding session, no Firebase CLI/project access here).
+done from a coding session, no Firebase CLI/project access here). Persistence is explicitly set to
+`SESSION` (not Firebase's `LOCAL` default) — closing the tab/browser signs the admin back out
+automatically, at the owner's request; a same-tab refresh still keeps the session, since
+`sessionStorage` (what `SESSION` persistence uses) survives a reload, just not closing the tab.
 
 The client-side button-hiding (`auth.onAuthStateChanged` toggling `editButtons`/`separators`) is
 **cosmetic only** — it exists so a random visitor doesn't see admin controls cluttering the page,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,18 @@ with admin-only upload/tagging/organizing tools. Deployed on Netlify.
     reuse `compressImageIfNeeded()`/`uploadImage()` as-is (same Cloudinary path as admin uploads),
     sequentially rather than in parallel, for the same reason upload.js's `Unexpected end of form`
     fix made the admin upload dock sequential (see above).
+  - Each submission also fires a best-effort email notification (2026-07-30,
+    `sendSubmissionEmailNotification()`) to **isakovicadrien@gmail.com** via FormSubmit's AJAX
+    relay (`https://formsubmit.co/ajax/...`) — chosen specifically to avoid standing up any new
+    backend/API key for this. **That inbox must click the one-time "activate this inbox" email
+    FormSubmit sends on the very first real submission**, or silently no notifications will ever
+    arrive (the Firestore `submissions` doc still gets written regardless — that's the durable
+    record; the email is just a heads-up, and its failure is caught and logged, not surfaced to
+    the submitter). The destination address is a plain string in the client-side fetch call, so
+    it's visible in the browser's network tab to anyone who looks, even though it's never printed
+    anywhere in the page's own UI — that's an inherent trade-off of doing this with no backend of
+    our own, not an oversight. If this address ever needs to change, it's a single string to edit
+    in `index.html`, not an env var.
 - **`netlify/functions/upload.js`** — receives multipart uploads (Busboy), pushes the file to
   Cloudinary, pre-generates 1200px/1920px derived sizes (`eager`) so the frontend's
   `cloudinaryDisplayUrl()` requests don't transform on first view.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,38 +39,51 @@ with admin-only upload/tagging/organizing tools. Deployed on Netlify.
   - "Submit" (2026-07-30, `submitReferenceBtn`/`submitReferenceModal`) is deliberately **not**
     admin-gated — it's the public-facing counterpart to the admin tools above, for visitors who
     want to send the site owner a link (e.g. a Drive folder) or images without needing an email
-    address. It's **email-only, on purpose**: submitting fires `sendSubmissionEmailNotification()`,
-    which posts straight to FormSubmit's AJAX relay (`https://formsubmit.co/ajax/...`) addressed
-    to **isakovicadrien@gmail.com**, and that's it — nothing is written to Firestore, nothing
-    touches `images`/`folders`, and there is deliberately no second place (like a Firestore
-    collection) to go check for these. The site owner explicitly asked for exactly this: receive
-    submissions by email, then decide by hand whether to add anything through the existing Add
-    Image flow. **Don't reintroduce a Firestore write for submissions** without a fresh explicit
-    request - that was tried once in this same feature and rejected specifically because it created
-    a second, easy-to-forget-about place submissions could land invisibly. Because there's no
-    backend of our own here, a failed/unreachable relay call is a hard, user-visible error (not a
-    silently-swallowed one) — email is the *only* delivery path, so the submitter needs to know if
-    it didn't go through. **isakovicadrien@gmail.com must click the one-time "activate this inbox"
-    email FormSubmit sends on the very first real submission**, or every submission after that will
-    keep failing loudly until that's done. The destination address is a plain string in the
-    client-side fetch call, so it's visible in the browser's network tab to anyone who looks, even
-    though it's never printed anywhere in the page's own UI — an inherent trade-off of doing this
-    with no backend of our own, not an oversight. If the address ever needs to change, it's a
-    single string to edit in `index.html`, not an env var. Image uploads reuse
-    `compressImageIfNeeded()`/`uploadImage()` as-is (same Cloudinary path as admin uploads),
-    sequentially rather than in parallel, for the same reason upload.js's `Unexpected end of form`
-    fix made the admin upload dock sequential (see above) — so the images themselves do land in
-    Cloudinary (their URLs are what gets emailed), just not in Firestore/the gallery.
+    address. Submitting writes a doc to the `submissions` Firestore collection (`link`,
+    `imageUrls`, `note`, `timestamp`) — **this went through two reversals in the same session,
+    worth understanding before touching it again**: first it wrote to Firestore as a backup
+    alongside email; then, misread as "automatically adds to the gallery," it was stripped down to
+    email-only; then, once the real problem turned out to be "opening 40 individual email links
+    one at a time is unworkable," Firestore storage came back — this time specifically to back the
+    **Review Submissions** admin panel (see below), not as a backup. The Firestore write is what
+    must succeed for a submission to count; the email (`sendSubmissionEmailNotification()`, via
+    FormSubmit's AJAX relay to **isakovicadrien@gmail.com**) is fire-and-forget on top of it, just
+    a heads-up ping, and its failure is only logged (`.catch()` at the call site), never surfaced
+    to the submitter. **isakovicadrien@gmail.com must click the one-time "activate this inbox"**
+    email FormSubmit sends on the very first real submission, or the ping just silently never
+    arrives — annoying but not load-bearing, since the Firestore doc (and thus the review panel)
+    is unaffected either way. Image uploads reuse `compressImageIfNeeded()`/`uploadImage()` as-is
+    (same Cloudinary path as admin uploads), sequentially rather than in parallel, for the same
+    reason upload.js's `Unexpected end of form` fix made the admin upload dock sequential (see
+    above).
+  - **Review Submissions** (2026-07-30, `reviewSubmissionsBtn`/`reviewSubmissionsModal`) is the
+    admin-only screen that reads the `submissions` collection above: every pending submission
+    rendered as real image thumbnails (not raw links) with a per-image folder picker + "Add"
+    button, so reviewing a batch of e.g. 40 submitted images means glancing at a grid and clicking
+    "Add" on the ones worth keeping, not opening 40 links one at a time. "Add" reuses
+    `saveImageToFirebase()`/`addImageToGallery()` **directly** — the image is already sitting on
+    Cloudinary from the original submission, so this is not a re-upload, just the same two calls
+    `completeUpload()` makes after a normal admin upload finishes. "Dismiss" hard-deletes the
+    submission's Firestore doc once it's been dealt with (whether 0, some, or all of its images
+    got added) — there's no "mark as reviewed" limbo state, so don't add one without a reason;
+    the point was to keep the queue short, not to grow a permanent log.
 - **`netlify/functions/upload.js`** — receives multipart uploads (Busboy), pushes the file to
   Cloudinary, pre-generates 1200px/1920px derived sizes (`eager`) so the frontend's
   `cloudinaryDisplayUrl()` requests don't transform on first view.
 - **`netlify/functions/cloudVision.js`** — calls Google Cloud Vision (`LABEL_DETECTION`) to tag
   an uploaded image; falls back to client-side MobileNet (TensorFlow.js, loaded from a CDN) if
   Vision fails or the key is missing.
-- **Firestore** — two collections: `folders` (name, parent) and `images` (url, folder, keywords,
-  filename, timestamp). No auth backing this — see "Admin access" below. Public "Submit"
-  submissions deliberately do **not** go through Firestore at all — see the "Submit" note above.
+- **Firestore** — three collections: `folders` (name, parent), `images` (url, folder, keywords,
+  filename, timestamp), and `submissions` (link, imageUrls, note, timestamp — see "Submit" above).
+  Access is controlled by real Firestore security rules now — see "Admin access" below and
+  `firestore.rules`.
 - **Cloudinary** — actual image storage/hosting + on-the-fly resizing via URL transforms.
+- **`firestore.rules`** — the security rules text, checked into this repo **for reference only**.
+  There's no `firebase.json`/`.firebaserc` here and this session has no Firebase CLI access, so
+  this file is **not** deployed automatically by anything — it has to be manually pasted into
+  Firebase Console → Firestore Database → Rules any time it changes, and it's on whoever does
+  that to keep this file in sync with what's actually live. Don't assume editing it or committing
+  it has any live effect on its own.
 
 ## Environment variables (Netlify)
 
@@ -85,19 +98,33 @@ with admin-only upload/tagging/organizing tools. Deployed on Netlify.
 
 ## Admin access
 
-There's no real auth. "ADMIN ACCESS" opens a `UI Preferences` modal (`#userPreference` field,
-`#applyPreferenceBtn`) that reveals the edit buttons (add/move/delete/rename folders+images,
-edit image tags, find duplicates) on Apply.
+**2026-07-30: real auth, replacing the no-password gate below.** "ADMIN ACCESS" now opens an
+`#adminLoginModal` (email + password) that calls Firebase Auth's
+`signInWithEmailAndPassword()`. There is exactly **one** admin account, created manually in
+Firebase Console → Authentication → Users, using **isakovicadrien@gmail.com** (the Email/Password
+sign-in method must be enabled first, under Authentication → Sign-in method — neither step can be
+done from a coding session, no Firebase CLI/project access here).
 
-**2026-07-28: the password check was intentionally removed, at the site owner's explicit
-request ("no password for admin for now").** `applyPreferenceBtn`'s click handler now grants
-admin controls unconditionally — it no longer compares `#userPreference` against the old
-base64'd value. The modal/button/field are still there (least invasive change), just gated on
-nothing. This directly reverses the previous "keep the gate as-is" guidance below, which stood
-only until someone actually asked for it to change — now it has been asked. If you're picking
-this back up: don't silently re-add a password check, and don't silently remove the gate
-further (e.g. deleting the button/modal) without a fresh explicit request either way — confirm
-with the user before changing this again in either direction.
+The client-side button-hiding (`auth.onAuthStateChanged` toggling `editButtons`/`separators`) is
+**cosmetic only** — it exists so a random visitor doesn't see admin controls cluttering the page,
+nothing more. The actual enforcement is `firestore.rules`: writes to `folders`/`images`, and
+reads/writes to `submissions`, require `request.auth.token.email == 'isakovicadrien@gmail.com'`.
+This means even someone who forces the hidden buttons visible via devtools still can't write
+anything without actually authenticating as that exact account — unlike the previous gate, this
+one holds up against a technical visitor reading the page's source, which was the specific
+complaint that prompted this change. **The Firestore rules must actually be pasted into the
+Firebase Console for any of this to be real** — until then, whatever rules are currently live
+there are what's actually enforced, regardless of what `firestore.rules` in this repo says.
+
+**Superseded history, kept for context:** on 2026-07-28 the password check was intentionally
+*removed* entirely, at the site owner's explicit request ("no password for admin for now") —
+`applyPreferenceBtn` granted admin controls unconditionally, gated on nothing. That decision stood
+only until the site owner ran into a concrete problem it caused (an admin-only "Review
+Submissions" panel needed to exist, and a client-side-only gate around it was explicitly called
+out as insufficient — "can be opened by anyone that decoded the password in the script"). If
+you're picking this back up again: don't silently weaken this back to a client-side-only check,
+and don't silently change the sign-in method or which account(s) count as admin, without a fresh
+explicit request either way.
 
 ## Testing
 
@@ -110,8 +137,12 @@ with the user before changing this again in either direction.
   with Playwright/a headless browser. Firebase and the TensorFlow/MobileNet CDN scripts may be
   unreachable in a sandboxed session (egress policy blocking `cdn.jsdelivr.net`/`gstatic.com`) —
   in that case, stub `window.firebase` via `page.addInitScript()` before navigating so the
-  top-level `firebase.initializeApp()`/`firebase.firestore()` calls don't throw and the rest of
-  the inline script (event listener wiring) still runs.
+  top-level `firebase.initializeApp()`/`firebase.firestore()`/`firebase.auth()` calls don't throw
+  and the rest of the inline script (event listener wiring) still runs. The stub needs a fake
+  `auth()` too now (not just `firestore()`) to test anything admin-gated: at minimum
+  `onAuthStateChanged(cb)` (call `cb` immediately, keep it to notify on sign-in/out),
+  `signInWithEmailAndPassword(email, password)`, `signOut()`, and a `currentUser` getter — real
+  Firebase Auth can't run in this sandbox any more than real Firestore can.
 
 ## Working across sessions
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,38 @@
+rules_version = '2';
+
+// Reference only - NOT auto-deployed. This repo has no Firebase CLI config
+// (no firebase.json / .firebaserc), so any change here must also be pasted
+// manually into the Firebase Console (Firestore Database -> Rules). Keep
+// this file in sync with whatever's actually live there, but don't assume
+// pushing this file to git does anything on its own.
+//
+// The admin email hardcoded below is the one Firebase Auth (Email/Password)
+// account allowed to write to folders/images and to read/manage
+// submissions. Create that account in Firebase Console -> Authentication ->
+// Users, after enabling the Email/Password sign-in method under
+// Authentication -> Sign-in method.
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // Public gallery data: anyone can read, only the admin account can write.
+    match /folders/{folderId} {
+      allow read: if true;
+      allow write: if request.auth != null
+        && request.auth.token.email == 'isakovicadrien@gmail.com';
+    }
+    match /images/{imageId} {
+      allow read: if true;
+      allow write: if request.auth != null
+        && request.auth.token.email == 'isakovicadrien@gmail.com';
+    }
+
+    // Public "Submit" button: anyone can create a submission with no login
+    // (allow create: if true), but only the admin account can list, read,
+    // update, or delete them - so other visitors' submitted links/notes/
+    // images stay private, visible only in the Review Submissions panel.
+    match /submissions/{submissionId} {
+      allow create: if true;
+      allow read, update, delete: if request.auth != null
+        && request.auth.token.email == 'isakovicadrien@gmail.com';
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -96,27 +96,29 @@
   color: var(--text);
 }
 
-/* Submit Reference Button CSS - stacked under About, same footprint so it
-   doesn't need its own clearance from the search bar's padding-right */
+/* Submit Reference Button CSS - sits on the same row as About, just to its
+   left, with matching visual weight so it doesn't read as an accidental
+   floating fragment. Same box model as .about-btn, different `right`. */
 .submit-reference-btn {
   position: absolute;
-  top: 65px;
-  right: 40px;
-  background-color: rgba(24, 24, 27, 0.35);
-  color: var(--text-faint);
+  top: 15px;
+  right: 172px;
+  background-color: rgba(24, 24, 27, 0.45);
+  color: var(--text-muted);
   border: 1px solid var(--border-color);
-  padding: 8px 16px;
+  padding: 10px 16px;
   border-radius: 12px;
-  font-size: 0.85rem;
+  font-size: 0.95rem;
   font-weight: 400;
   cursor: pointer;
   width: 120px;
   text-align: center;
   z-index: 1200;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
-  height: 34px;
-  line-height: 18px;
+  height: 40px;
+  line-height: 20px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -124,7 +126,7 @@
 }
 
 .submit-reference-btn:hover {
-  background-color: rgba(32, 32, 36, 0.75);
+  background-color: rgba(32, 32, 36, 0.8);
   border-color: var(--border-strong);
   color: var(--text);
 }
@@ -949,12 +951,14 @@
 .top-search-bar {
   position: absolute;
   top: 15px;
-  /* Fills the full width between the sidebar and the About button, each
-     kept as an explicit margin (left / padding-right below) rather than
-     centering a fixed-width pill with empty space on both sides. */
+  /* Fills the full width between the sidebar and the About/Submit button
+     pair, each kept as an explicit margin (left / padding-right below)
+     rather than centering a fixed-width pill with empty space on both
+     sides. padding-right covers both buttons (Submit sits just left of
+     About - see .submit-reference-btn's `right`) plus a clear gap. */
   left: calc(var(--sidebar-width) + 1.2rem);
   right: 0.8rem;
-  padding-right: 180px;
+  padding-right: 310px;
   z-index: 1000;
   display: flex;
   justify-content: center;
@@ -1179,6 +1183,21 @@
 }
 
 /* --------------------------------------------------
+   Header button pair (Submit + About) shrinks a bit before the main
+   640px breakpoint - two side-by-side buttons need more reserved width
+   than About alone used to, and the gap between "everything still fits"
+   and "sidebar starts shrinking too" is otherwise too wide, cramping the
+   search input around tablet-ish widths.
+-------------------------------------------------- */
+@media (max-width: 900px) {
+  :root { --sidebar-width: 230px; }
+  .top-search-bar { padding-right: 230px; }
+  .about-btn { width: 90px; padding: 8px 10px; font-size: 0.85rem; }
+  .submit-reference-btn { width: 90px; right: 138px; padding: 8px 10px; font-size: 0.85rem; }
+  #mainImageSearch { padding: 8px 12px; font-size: 0.85rem; }
+}
+
+/* --------------------------------------------------
    Responsive layout for narrow windows
    (sidebar and header shrink so nothing overlaps
    or overflows the viewport)
@@ -1186,9 +1205,9 @@
 @media (max-width: 640px) {
   :root { --sidebar-width: 200px; }
   .sidebar { padding: 0.6rem; }
-  .top-search-bar { left: calc(var(--sidebar-width) + 0.8rem); right: 0.6rem; padding-right: 118px; top: 12px; }
+  .top-search-bar { left: calc(var(--sidebar-width) + 0.8rem); right: 0.6rem; padding-right: 206px; top: 12px; }
   .about-btn { top: 12px; right: 14px; width: 90px; padding: 8px 10px; font-size: 0.85rem; }
-  .submit-reference-btn { top: 60px; right: 14px; width: 90px; height: 30px; padding: 6px 8px; font-size: 0.75rem; }
+  .submit-reference-btn { top: 12px; right: 112px; width: 90px; height: 40px; padding: 8px 10px; font-size: 0.85rem; }
   #mainImageSearch { padding: 8px 12px; font-size: 0.85rem; }
   .main-content { padding-left: 0.6rem; padding-right: 0.6rem; padding-top: 70px; }
   .floating-size-panel { right: 12px; bottom: 12px; }
@@ -1196,13 +1215,16 @@
   .size-icon { width: 30px; height: 30px; font-size: 0.72rem; }
 }
 
-/* Extra-narrow phones: shrink the sidebar further so the search bar
-   keeps usable room next to it */
+/* Extra-narrow phones: shrink the sidebar further, and - since there's no
+   longer room for Submit + About beside the search bar too - drop them to
+   their own row below it instead of shrinking them to an illegibly small,
+   hard-to-tap size. */
 @media (max-width: 420px) {
   :root { --sidebar-width: 140px; }
-  .top-search-bar { left: calc(var(--sidebar-width) + 0.75rem); right: 0.6rem; padding-right: 100px; }
-  .about-btn { width: 78px; right: 10px; padding: 6px 8px; font-size: 0.78rem; }
-  .submit-reference-btn { width: 78px; right: 10px; padding: 5px 6px; font-size: 0.68rem; }
+  .top-search-bar { left: calc(var(--sidebar-width) + 0.75rem); right: 0.6rem; padding-right: 10px; }
+  .about-btn { top: 54px; width: 78px; right: 10px; padding: 6px 8px; font-size: 0.78rem; }
+  .submit-reference-btn { top: 54px; width: 78px; right: 94px; padding: 6px 8px; font-size: 0.78rem; }
+  .main-content { padding-top: 96px; }
 }
 
 .batch-tag-review-content {
@@ -1319,7 +1341,7 @@
     <div class="modal-content">
       <button class="close-modal-btn" id="closeSubmitReferenceModalBtn">&times;</button>
       <h3>Submit a Reference</h3>
-      <p style="margin-bottom: 0.8rem; opacity: 0.8;">Got a Google Drive link or some images to share? Send them here - no need to look up an email address.</p>
+      <p style="margin-bottom: 0.8rem; opacity: 0.8;">Got a Google Drive link or some images to share? Send them here.</p>
 
       <label for="submitReferenceLink">Link (optional):</label>
       <input type="url" id="submitReferenceLink" placeholder="https://drive.google.com/...">

--- a/index.html
+++ b/index.html
@@ -1890,6 +1890,31 @@ aboutModal.addEventListener("click", (e) => {
       submitReferenceStatus.textContent = "";
     }
 
+    // Best-effort email notification via FormSubmit's AJAX relay - no backend
+    // of our own, no API key. isakovicadrien@gmail.com must click the
+    // one-time "activate this inbox" email FormSubmit sends on the very
+    // first submission before notifications start arriving.
+    // Note this address is visible in the browser's network tab (it's a
+    // client-side POST), just never shown anywhere in the page's own UI.
+    async function sendSubmissionEmailNotification({ link, imageUrls, note }) {
+      const response = await fetch('https://formsubmit.co/ajax/isakovicadrien@gmail.com', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+        body: JSON.stringify({
+          _subject: 'New reference submission',
+          _template: 'box',
+          _captcha: 'false',
+          link: link || '(none)',
+          images: imageUrls.length ? imageUrls.join('\n') : '(none)',
+          note: note || '(none)'
+        })
+      });
+      if (!response.ok) {
+        throw new Error(`FormSubmit relay responded with ${response.status}`);
+      }
+      return response.json();
+    }
+
     async function submitReference() {
       const linkValue = submitReferenceLink.value.trim();
       const noteValue = submitReferenceNote.value.trim();
@@ -1914,13 +1939,26 @@ aboutModal.addEventListener("click", (e) => {
           imageUrls.push(url);
         }
 
-        await db.collection('submissions').add({
-          link: linkValue,
-          imageUrls: imageUrls,
-          note: noteValue,
-          timestamp: firebase.firestore.FieldValue.serverTimestamp(),
-          addTime: Date.now()
-        });
+        // Firestore is the durable record and must succeed; the email
+        // notification is best-effort and shouldn't fail the submission if
+        // the relay is down or not yet activated.
+        const [firestoreResult, emailResult] = await Promise.allSettled([
+          db.collection('submissions').add({
+            link: linkValue,
+            imageUrls: imageUrls,
+            note: noteValue,
+            timestamp: firebase.firestore.FieldValue.serverTimestamp(),
+            addTime: Date.now()
+          }),
+          sendSubmissionEmailNotification({ link: linkValue, imageUrls, note: noteValue })
+        ]);
+
+        if (firestoreResult.status === 'rejected') {
+          throw firestoreResult.reason;
+        }
+        if (emailResult.status === 'rejected') {
+          console.warn('Submission saved, but the email notification failed to send:', emailResult.reason);
+        }
 
         showSubmitReferenceStatus("Thanks! Your submission was received.", false);
         setTimeout(() => {

--- a/index.html
+++ b/index.html
@@ -28,6 +28,8 @@
       --success: #4cd964;
       --move-accent: #4d9bf5;
       --move-soft: rgba(77,155,245,0.16);
+      --tag-accent: #a374e0;
+      --tag-soft: rgba(163,116,224,0.16);
       --radius-xs: 6px;   /* images: micro rounding */
       --radius-sm: 8px;
       --radius-md: 12px;
@@ -724,6 +726,59 @@
     }
 
     /* --------------------------------------------------
+       Edit Tags Feature
+    -------------------------------------------------- */
+    .sidebar-footer button.tag-btn {
+      background-color: var(--tag-soft);
+      color: var(--tag-accent);
+      border-color: transparent;
+    }
+    .image-container.tag-selectable { position: relative; }
+    .image-container.tag-selectable::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background-color: rgba(163,116,224,0.18);
+      border: 2px dashed rgba(163,116,224,0.6);
+      border-radius: inherit;
+      z-index: 1;
+      pointer-events: none;
+    }
+    .image-container.tag-selected::before {
+      background-color: rgba(163,116,224,0.42);
+      border: 2px solid var(--tag-accent);
+    }
+    .tag-edit-controls {
+      position: fixed;
+      bottom: 80px;
+      left: 50%;
+      transform: translateX(-50%);
+      background-color: rgba(26,26,30,0.9);
+      border: 1px solid var(--border-color);
+      backdrop-filter: blur(10px);
+      padding: 0.5rem 1rem;
+      border-radius: var(--radius-md);
+      z-index: 1000;
+      display: none;
+      align-items: center;
+      justify-content: center;
+      gap: 0.5rem;
+      box-shadow: var(--shadow-md);
+    }
+    .tag-edit-controls.active { display: flex; }
+    .tag-edit-controls button {
+      background-color: var(--tag-accent);
+      color: white;
+      border: none;
+      padding: 0.4rem 0.8rem;
+      border-radius: var(--radius-sm);
+      font-size: 0.85rem;
+      font-weight: 600;
+      cursor: pointer;
+    }
+    .tag-edit-controls button.cancel { background-color: rgba(255,255,255,0.12); color: var(--text); }
+
+    /* --------------------------------------------------
        Enlarge Image Modal (Lightbox)
     -------------------------------------------------- */
    #enlargeImageModal {
@@ -1249,6 +1304,7 @@
         <hr class="separator">
         <div class="admin-bottom-buttons">
           <button id="moveImageBtn" class="move-btn">Move Images</button>
+          <button id="editTagsBtn" class="tag-btn">Edit Tags</button>
           <button id="renameFolderBtn">Rename Folder</button>
           <button id="deleteImageBtn" class="delete-btn">Delete Images</button>
           <button id="deleteFolderBtn" class="delete-btn">Delete Folder</button>
@@ -1265,6 +1321,12 @@
       <span id="moveSelectedCount">0 selected</span>
       <button id="confirmMoveImagesBtn">Select Destination</button>
       <button id="cancelMoveImagesBtn" class="cancel">Cancel</button>
+    </div>
+    <!-- Edit Tags Controls -->
+    <div class="tag-edit-controls" id="tagEditControls">
+      <span id="tagEditSelectedCount">0 selected</span>
+      <button id="confirmTagEditBtn">Edit Tags</button>
+      <button id="cancelTagEditBtn" class="cancel">Cancel</button>
     </div>
     <!-- MAIN CONTENT -->
     <div class="main-content">
@@ -1361,6 +1423,18 @@
       </div>
     </div>
   </div>
+  <!-- MODAL: Edit Tags -->
+  <div class="modal-backdrop" id="editTagsModal">
+    <div class="modal-content batch-tag-review-content">
+      <button class="close-modal-btn" id="closeEditTagsModalBtn">&times;</button>
+      <h3>Edit Tags <span id="editTagsCount"></span></h3>
+      <p style="margin-bottom: 0.8rem;">Edit tags for each selected image, then save them all at once.</p>
+      <div id="editTagsList" class="batch-review-list"></div>
+      <div style="margin-top:0.8rem;">
+        <button id="saveEditTagsBtn">Save All</button>
+      </div>
+    </div>
+  </div>
 <!-- MODAL: Duplicate Images -->
 <div class="modal-backdrop" id="duplicatesModal">
   <div class="modal-content">
@@ -1425,6 +1499,10 @@
     let selectedImages = [];
     let isMoveMode = false;
     let selectedImagesForMove = [];
+    let isTagEditMode = false;
+    let selectedImagesForTagEdit = [];
+    // { container, input } pairs for the currently open Edit Tags modal
+    let tagEditRows = [];
     // Batch tag review: images that finished uploading + tagging, awaiting the
     // single end-of-batch review screen
     let batchReviewItems = [];
@@ -1476,6 +1554,18 @@
     const closeMoveDestinationModalBtn = document.getElementById("closeMoveDestinationModalBtn");
     const moveDestinationSelect = document.getElementById("moveDestinationSelect");
     const confirmMoveDestinationBtn = document.getElementById("confirmMoveDestinationBtn");
+
+    // Edit Tags elements
+    const editTagsBtn = document.getElementById("editTagsBtn");
+    const tagEditControls = document.getElementById("tagEditControls");
+    const tagEditSelectedCount = document.getElementById("tagEditSelectedCount");
+    const confirmTagEditBtn = document.getElementById("confirmTagEditBtn");
+    const cancelTagEditBtn = document.getElementById("cancelTagEditBtn");
+    const editTagsModal = document.getElementById("editTagsModal");
+    const closeEditTagsModalBtn = document.getElementById("closeEditTagsModalBtn");
+    const editTagsList = document.getElementById("editTagsList");
+    const editTagsCount = document.getElementById("editTagsCount");
+    const saveEditTagsBtn = document.getElementById("saveEditTagsBtn");
 
     // Admin sidebar buttons
     const newFolderAdminBtn = document.getElementById("newFolderAdminBtn");
@@ -1926,10 +2016,14 @@ aboutModal.addEventListener("click", (e) => {
       }
       // Enlarge image on click
       img.addEventListener("click", function(e) {
-        // When in delete or move mode, don't trigger the enlarge modal.
-        if (isDeleteMode || isMoveMode) return;
+        // When in delete, move, or tag-edit mode, don't trigger the enlarge modal.
+        if (isDeleteMode || isMoveMode || isTagEditMode) return;
         e.stopPropagation();
-        enlargeImage(url, filename, keywords);
+        // Read tags from the live attribute rather than the closed-over
+        // `keywords` param - Edit Tags updates data-keywords in place, and
+        // this param would otherwise keep showing whatever the image had
+        // when it was first added to the gallery.
+        enlargeImage(url, filename, container.getAttribute('data-keywords') || '');
       });
 
 // Replace your existing download link creation code with this:
@@ -2246,8 +2340,10 @@ downloadLink.addEventListener("click", function(e) {
      ********************************************************/
     function toggleDeleteMode() {
       isDeleteMode = !isDeleteMode;
-      
+
       if (isDeleteMode) {
+        if (isMoveMode) toggleMoveMode();
+        if (isTagEditMode) toggleTagEditMode();
         const allImages = document.querySelectorAll(".image-container");
         allImages.forEach(container => {
           container.classList.add("selectable");
@@ -2316,8 +2412,10 @@ downloadLink.addEventListener("click", function(e) {
      ********************************************************/
     function toggleMoveMode() {
       isMoveMode = !isMoveMode;
-      
+
       if (isMoveMode) {
+        if (isDeleteMode) toggleDeleteMode();
+        if (isTagEditMode) toggleTagEditMode();
         const allImages = document.querySelectorAll(".image-container");
         allImages.forEach(container => {
           container.classList.add("move-selectable");
@@ -2421,7 +2519,124 @@ downloadLink.addEventListener("click", function(e) {
       }
     }
 
-   
+    /********************************************************
+     * Edit Tags Functions
+     ********************************************************/
+    function toggleTagEditMode() {
+      isTagEditMode = !isTagEditMode;
+
+      if (isTagEditMode) {
+        if (isDeleteMode) toggleDeleteMode();
+        if (isMoveMode) toggleMoveMode();
+        const allImages = document.querySelectorAll(".image-container");
+        allImages.forEach(container => {
+          container.classList.add("tag-selectable");
+          container.addEventListener("click", toggleImageTagEditSelection);
+        });
+        tagEditControls.classList.add("active");
+        updateTagEditSelectedCount();
+      } else {
+        const allImages = document.querySelectorAll(".image-container");
+        allImages.forEach(container => {
+          container.classList.remove("tag-selectable");
+          container.classList.remove("tag-selected");
+          container.removeEventListener("click", toggleImageTagEditSelection);
+        });
+        tagEditControls.classList.remove("active");
+        selectedImagesForTagEdit = [];
+      }
+    }
+
+    function toggleImageTagEditSelection(e) {
+      e.preventDefault();
+      e.stopPropagation();
+      const container = e.currentTarget;
+      if (!isTagEditMode) return;
+      if (container.classList.contains("tag-selected")) {
+        container.classList.remove("tag-selected");
+        const index = selectedImagesForTagEdit.findIndex(img => img === container);
+        if (index !== -1) { selectedImagesForTagEdit.splice(index, 1); }
+      } else {
+        container.classList.add("tag-selected");
+        selectedImagesForTagEdit.push(container);
+      }
+      updateTagEditSelectedCount();
+    }
+
+    function updateTagEditSelectedCount() {
+      tagEditSelectedCount.textContent = `${selectedImagesForTagEdit.length} selected`;
+    }
+
+    function showEditTagsModal() {
+      if (selectedImagesForTagEdit.length === 0) {
+        alert("Please select at least one image to edit tags for.");
+        return;
+      }
+      populateEditTagsList();
+      editTagsModal.classList.add("active");
+    }
+
+    // Builds one editable row per selected image, reusing the same
+    // .batch-review-* markup/styling as the upload batch tag review panel.
+    function populateEditTagsList() {
+      editTagsList.innerHTML = "";
+      editTagsCount.textContent = `(${selectedImagesForTagEdit.length})`;
+      tagEditRows = selectedImagesForTagEdit.map(container => {
+        const row = document.createElement("div");
+        row.className = "batch-review-row";
+
+        const thumb = document.createElement("img");
+        thumb.className = "batch-review-thumb";
+        thumb.src = container.querySelector("img").src;
+        row.appendChild(thumb);
+
+        const info = document.createElement("div");
+        info.className = "batch-review-info";
+
+        const filename = document.createElement("div");
+        filename.className = "batch-review-filename";
+        filename.textContent = container.querySelector("img").alt || "image";
+        info.appendChild(filename);
+
+        const tagsInput = document.createElement("input");
+        tagsInput.type = "text";
+        tagsInput.className = "batch-review-tags-input";
+        tagsInput.placeholder = "Edit or add tags...";
+        tagsInput.value = container.getAttribute("data-keywords") || "";
+        info.appendChild(tagsInput);
+
+        row.appendChild(info);
+        editTagsList.appendChild(row);
+
+        return { container, input: tagsInput };
+      });
+    }
+
+    async function saveEditedTags() {
+      if (tagEditRows.length === 0) return;
+      try {
+        const savePromises = tagEditRows.map(async ({ container, input }) => {
+          const newTags = input.value.trim();
+          const previousTags = container.getAttribute("data-keywords") || "";
+          if (newTags === previousTags) return true; // nothing changed, skip the write
+          const imageUrl = container.dataset.url;
+          const imageId = await findImageIdByUrl(imageUrl);
+          if (imageId) {
+            await db.collection('images').doc(imageId).update({ keywords: newTags });
+            container.setAttribute('data-keywords', newTags);
+            return true;
+          }
+          return false;
+        });
+        await Promise.all(savePromises);
+        tagEditRows = [];
+        editTagsModal.classList.remove("active");
+        toggleTagEditMode();
+      } catch (error) {
+        console.error('Error saving tags:', error);
+        alert(`Error saving tags: ${error.message}`);
+      }
+    }
 
     /********************************************************
      * Enlarge Image Modal Closure (click outside image)
@@ -3429,6 +3644,14 @@ async function completeUpload(imageUrl, folderValue, combinedKeywords, fileName,
     closeMoveDestinationModalBtn.addEventListener("click", () => { moveDestinationModal.classList.remove("active"); });
     moveDestinationModal.addEventListener("click", (e) => { if (e.target === moveDestinationModal) { moveDestinationModal.classList.remove("active"); } });
     confirmMoveDestinationBtn.addEventListener("click", moveImagesToDestination);
+
+    editTagsBtn.addEventListener("click", toggleTagEditMode);
+    confirmTagEditBtn.addEventListener("click", showEditTagsModal);
+    cancelTagEditBtn.addEventListener("click", toggleTagEditMode);
+
+    closeEditTagsModalBtn.addEventListener("click", () => { editTagsModal.classList.remove("active"); });
+    editTagsModal.addEventListener("click", (e) => { if (e.target === editTagsModal) { editTagsModal.classList.remove("active"); } });
+    saveEditTagsBtn.addEventListener("click", saveEditedTags);
 
     filterButton.addEventListener("click", (e) => {
       e.stopPropagation();

--- a/index.html
+++ b/index.html
@@ -1302,6 +1302,83 @@
   margin-bottom: 0.8rem;
 }
 
+/* --------------------------------------------------
+   Review Submissions Panel
+-------------------------------------------------- */
+.submissions-review-content {
+  max-width: 820px;
+}
+#reviewSubmissionsList {
+  max-height: 65vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.submission-row {
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  padding: 10px;
+  background: var(--bg-sunken);
+}
+.submission-meta {
+  font-size: 0.78rem;
+  color: var(--text-faint);
+  margin-bottom: 6px;
+}
+.submission-link {
+  display: block;
+  font-size: 0.88rem;
+  margin-bottom: 6px;
+  word-break: break-all;
+  color: var(--accent);
+}
+.submission-note {
+  font-size: 0.88rem;
+  margin-bottom: 8px;
+  color: var(--text-muted);
+}
+.submission-images {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+.submission-image-item {
+  width: 104px;
+}
+.submission-image-item img {
+  width: 104px;
+  height: 104px;
+  object-fit: cover;
+  border-radius: var(--radius-xs);
+  border: 1px solid var(--border-color);
+  display: block;
+  margin-bottom: 4px;
+}
+.submission-image-item select {
+  width: 100%;
+  font-size: 0.72rem;
+  padding: 2px 4px;
+  margin-bottom: 4px;
+  background-color: var(--bg-elevated);
+  color: var(--text);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-xs);
+}
+.submission-image-item button {
+  width: 100%;
+  font-size: 0.72rem;
+  padding: 3px 4px;
+}
+.submission-image-item button:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+.submission-dismiss-btn {
+  background-color: var(--danger) !important;
+}
+
   </style>
 
  <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@3.18.0"></script>
@@ -1399,6 +1476,7 @@
           <button id="deleteImageBtn" class="delete-btn">Delete Images</button>
           <button id="deleteFolderBtn" class="delete-btn">Delete Folder</button>
           <button id="findDuplicatesBtn">Find Duplicates</button>
+          <button id="reviewSubmissionsBtn">Review Submissions</button>
         </div>
         <hr class="separator">
        <div class="sidebar-admin-section">
@@ -1535,15 +1613,27 @@
     <div id="duplicatesList" style="max-height: 50vh; overflow-y: auto;"></div>
   </div>
 </div>
-<!-- MODAL: UI Preferences -->
-<div class="modal-backdrop" id="preferencesPanel">
+<!-- MODAL: Review Submissions -->
+<div class="modal-backdrop" id="reviewSubmissionsModal">
+  <div class="modal-content submissions-review-content">
+    <button class="close-modal-btn" id="closeReviewSubmissionsModalBtn">&times;</button>
+    <h3>Review Submissions</h3>
+    <p style="margin-bottom: 0.8rem;">Links and images sent in through the public "Submit" button. Add whichever images are worth keeping to a folder, then dismiss the submission.</p>
+    <div id="reviewSubmissionsList"></div>
+  </div>
+</div>
+<!-- MODAL: Admin Sign In -->
+<div class="modal-backdrop" id="adminLoginModal">
   <div class="modal-content">
-    <button class="close-modal-btn" id="closePreferencesPanelBtn">&times;</button>
-    <h3>UI Preferences</h3>
-    <label for="userPreference">ID:</label>
-    <input type="password" id="userPreference" placeholder="Enter ID">
+    <button class="close-modal-btn" id="closeAdminLoginModalBtn">&times;</button>
+    <h3>Admin Sign In</h3>
+    <label for="adminEmailInput">Email:</label>
+    <input type="email" id="adminEmailInput" placeholder="you@example.com" autocomplete="username">
+    <label for="adminPasswordInput">Password:</label>
+    <input type="password" id="adminPasswordInput" placeholder="Password" autocomplete="current-password">
+    <div id="adminLoginError" class="modal-hint" style="display:none;"></div>
     <div style="margin-top:0.8rem;">
-      <button id="applyPreferenceBtn">Apply</button>
+      <button id="adminLoginBtn">Sign In</button>
     </div>
   </div>
 </div>
@@ -1556,6 +1646,7 @@
   <!-- Load Firebase SDKs via CDN -->
   <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-auth-compat.js"></script>
   <script>
     // Initialize Firebase with your configuration
     const firebaseConfig = {
@@ -1570,6 +1661,7 @@
       firebase.initializeApp(firebaseConfig);
     }
     const db = firebase.firestore();
+    const auth = firebase.auth();
 
     // Initial variables
     let folders = [
@@ -1661,30 +1753,79 @@
     const newFolderAdminBtn = document.getElementById("newFolderAdminBtn");
     const addImageAdminBtn = document.getElementById("addImageAdminBtn");
 
-    // Admin login elements
-    const adminBtn = document.getElementById("adminBtn");
-    const adminModal = document.getElementById("adminModal");
-    const closeAdminModalBtn = document.getElementById("closeAdminModalBtn");
-    const confirmAdminBtn = document.getElementById("confirmAdminBtn");
+    // Admin sign-in elements
+    const adminLoginModal = document.getElementById("adminLoginModal");
+    const closeAdminLoginModalBtn = document.getElementById("closeAdminLoginModalBtn");
+    const adminEmailInput = document.getElementById("adminEmailInput");
+    const adminPasswordInput = document.getElementById("adminPasswordInput");
+    const adminLoginError = document.getElementById("adminLoginError");
+    const adminLoginBtn = document.getElementById("adminLoginBtn");
 
-    // All editing buttons in the sidebar footer and separators
-    const editButtons = document.querySelectorAll(".sidebar-footer button:not(#adminaccessBtn)");
+    // Review Submissions elements
+    const reviewSubmissionsBtn = document.getElementById("reviewSubmissionsBtn");
+    const reviewSubmissionsModal = document.getElementById("reviewSubmissionsModal");
+    const closeReviewSubmissionsModalBtn = document.getElementById("closeReviewSubmissionsModalBtn");
+    const reviewSubmissionsList = document.getElementById("reviewSubmissionsList");
+
+    // All editing buttons in the sidebar footer and separators - shown/hidden
+    // by the onAuthStateChanged listener below, not by this initial pass.
+    // This is a UI convenience only: the real gate is the Firestore security
+    // rules keyed on the signed-in user's exact email, so even someone who
+    // forces these buttons visible via devtools still can't actually write
+    // anything without being authenticated as the admin account.
+    const editButtons = document.querySelectorAll(".sidebar-footer button:not(#adminaccessbtn)");
     const separators = document.querySelectorAll(".separator");
 
-    
-
-    // Hide edit buttons and separators by default
-      editButtons.forEach(button => { button.style.display = "none"; });
-      separators.forEach(separator => { separator.style.display = "none"; });
-  
+    editButtons.forEach(button => { button.style.display = "none"; });
+    separators.forEach(separator => { separator.style.display = "none"; });
 
     const mainImageSearch = document.getElementById("mainImageSearch");
 
     const adminAccessBtn = document.getElementById("adminaccessbtn");
 
-   document.getElementById("adminaccessbtn").addEventListener("click", () => {
-   document.getElementById("preferencesPanel").classList.add("active");
-});
+    adminAccessBtn.addEventListener("click", () => {
+      if (auth.currentUser) {
+        auth.signOut();
+      } else {
+        adminLoginError.style.display = "none";
+        adminLoginModal.classList.add("active");
+      }
+    });
+
+    closeAdminLoginModalBtn.addEventListener("click", () => { adminLoginModal.classList.remove("active"); });
+    adminLoginModal.addEventListener("click", (e) => { if (e.target === adminLoginModal) { adminLoginModal.classList.remove("active"); } });
+
+    adminLoginBtn.addEventListener("click", async () => {
+      const email = adminEmailInput.value.trim();
+      const password = adminPasswordInput.value;
+      adminLoginError.style.display = "none";
+      if (!email || !password) {
+        adminLoginError.textContent = "Enter both an email and a password.";
+        adminLoginError.style.display = "block";
+        return;
+      }
+      try {
+        await auth.signInWithEmailAndPassword(email, password);
+        adminEmailInput.value = "";
+        adminPasswordInput.value = "";
+        adminLoginModal.classList.remove("active");
+      } catch (error) {
+        adminLoginError.textContent = `Sign in failed: ${error.message}`;
+        adminLoginError.style.display = "block";
+      }
+    });
+
+    // The single source of truth for whether admin controls show - fires
+    // once immediately with whatever session Firebase already has (e.g.
+    // still signed in from a previous visit), then again on every sign-in/
+    // sign-out.
+    auth.onAuthStateChanged((user) => {
+      const isSignedIn = !!user;
+      editButtons.forEach(button => { button.style.display = isSignedIn ? "block" : "none"; });
+      separators.forEach(separator => { separator.style.display = isSignedIn ? "block" : "none"; });
+      adminAccessBtn.textContent = isSignedIn ? "SIGN OUT" : "ADMIN ACCESS";
+      adminAccessBtn.style.display = "block";
+    });
 
     /********************************************************
      * Justified Gallery Layout
@@ -1818,11 +1959,12 @@ aboutModal.addEventListener("click", (e) => {
     /********************************************************
      * Submit Reference (public - not admin-gated)
      * Lets anyone send a link and/or images without needing an email
-     * address. Emailed straight to the site owner (see
-     * sendSubmissionEmailNotification below) - not written to Firestore or
-     * the gallery at all, so nothing shows up publicly and there's no
-     * separate place to go check; reviewing and adding anything worth
-     * keeping is entirely manual, through the existing Add Image flow.
+     * address. Written to the 'submissions' Firestore collection - never
+     * the gallery's own 'images'/'folders' collections, so nothing shows
+     * up publicly - for review in the admin-only Review Submissions panel,
+     * plus a best-effort email heads-up (see sendSubmissionEmailNotification
+     * below). Reviewing and adding anything worth keeping is a deliberate,
+     * manual action taken from that panel, never automatic.
      ********************************************************/
     const submitReferenceBtn = document.getElementById("submitReferenceBtn");
     const submitReferenceModal = document.getElementById("submitReferenceModal");
@@ -1892,14 +2034,14 @@ aboutModal.addEventListener("click", (e) => {
       submitReferenceStatus.textContent = "";
     }
 
-    // Best-effort email notification via FormSubmit's AJAX relay - no backend
-    // of our own, no API key. isakovicadrien@gmail.com must click the
-    // one-time "activate this inbox" email FormSubmit sends on the very
-    // first submission before notifications start arriving. This email is
-    // the only record of a submission - deliberately not also written to
-    // Firestore, so there isn't a second place to check for these; the site
-    // owner wants to receive them by email and add anything worth keeping
-    // by hand through the existing Add Image flow, nothing automatic.
+    // Best-effort email heads-up via FormSubmit's AJAX relay - no backend of
+    // our own, no API key. isakovicadrien@gmail.com must click the one-time
+    // "activate this inbox" email FormSubmit sends on the very first
+    // submission before notifications start arriving. This is just a ping;
+    // the actual review happens in the Review Submissions panel, which reads
+    // the Firestore doc written alongside this call, so a failed/slow email
+    // here is only logged (see the .catch() at the call site), never a
+    // reason to fail the submission.
     // Note this address is visible in the browser's network tab (it's a
     // client-side POST), just never shown anywhere in the page's own UI.
     async function sendSubmissionEmailNotification({ link, imageUrls, note }) {
@@ -1945,7 +2087,19 @@ aboutModal.addEventListener("click", (e) => {
           imageUrls.push(url);
         }
 
-        await sendSubmissionEmailNotification({ link: linkValue, imageUrls, note: noteValue });
+        // The Firestore write is what the Review Submissions panel actually
+        // reads, so it's what must succeed. The email is just a heads-up on
+        // top of it - fire-and-forget, not awaited, so a slow/unreachable
+        // relay can't delay or fail an otherwise-successful submission.
+        await db.collection('submissions').add({
+          link: linkValue,
+          imageUrls: imageUrls,
+          note: noteValue,
+          timestamp: firebase.firestore.FieldValue.serverTimestamp(),
+          addTime: Date.now()
+        });
+        sendSubmissionEmailNotification({ link: linkValue, imageUrls, note: noteValue })
+          .catch(error => console.warn('Submission saved, but the email notification failed to send:', error));
 
         showSubmitReferenceStatus("Thanks! Your submission was received.", false);
         setTimeout(() => {
@@ -3246,6 +3400,145 @@ function closeEnlargeModal() {
     closeDuplicatesModalBtn.addEventListener("click", () => { duplicatesModal.classList.remove("active"); });
     duplicatesModal.addEventListener("click", (e) => { if (e.target === duplicatesModal) duplicatesModal.classList.remove("active"); });
 
+    /********************************************************
+     * Review Submissions
+     * Admin-only view of what's landed in the 'submissions' collection via
+     * the public Submit button. Each image gets its own folder picker so
+     * they can be added independently (skip the ones not worth keeping) -
+     * adding reuses saveImageToFirebase()/addImageToGallery() directly since
+     * the file is already on Cloudinary from the original submission, no
+     * re-upload needed. Dismissing a submission deletes its Firestore doc
+     * entirely once it's been dealt with (added, some, all, or none).
+     ********************************************************/
+    function populateFolderSelectOptions(selectEl) {
+      selectEl.innerHTML = '<option value="">Choose folder…</option>';
+      const structure = buildFolderStructure();
+      Object.keys(structure).sort().forEach(parent => {
+        const opt = document.createElement("option");
+        opt.value = parent;
+        opt.textContent = parent;
+        selectEl.appendChild(opt);
+        (structure[parent] || []).forEach(child => {
+          const childOpt = document.createElement("option");
+          childOpt.value = parent + "/" + child;
+          childOpt.textContent = "— " + child;
+          selectEl.appendChild(childOpt);
+        });
+      });
+    }
+
+    function renderSubmissionRow(id, data) {
+      const row = document.createElement("div");
+      row.className = "submission-row";
+
+      const meta = document.createElement("div");
+      meta.className = "submission-meta";
+      const when = data.addTime ? new Date(data.addTime).toLocaleString() : "";
+      meta.textContent = when;
+      row.appendChild(meta);
+
+      if (data.link) {
+        const link = document.createElement("a");
+        link.className = "submission-link";
+        link.href = data.link;
+        link.target = "_blank";
+        link.rel = "noopener noreferrer";
+        link.textContent = data.link;
+        row.appendChild(link);
+      }
+
+      if (data.note) {
+        const note = document.createElement("div");
+        note.className = "submission-note";
+        note.textContent = data.note;
+        row.appendChild(note);
+      }
+
+      if (Array.isArray(data.imageUrls) && data.imageUrls.length > 0) {
+        const imagesWrap = document.createElement("div");
+        imagesWrap.className = "submission-images";
+        data.imageUrls.forEach(url => {
+          const item = document.createElement("div");
+          item.className = "submission-image-item";
+
+          const thumb = document.createElement("img");
+          thumb.src = cloudinaryDisplayUrl(url, { width: 300 });
+          item.appendChild(thumb);
+
+          const folderSelectEl = document.createElement("select");
+          populateFolderSelectOptions(folderSelectEl);
+          item.appendChild(folderSelectEl);
+
+          const addBtn = document.createElement("button");
+          addBtn.type = "button";
+          addBtn.textContent = "Add";
+          addBtn.addEventListener("click", async () => {
+            const folder = folderSelectEl.value;
+            if (!folder) { alert("Choose a folder first."); return; }
+            addBtn.disabled = true;
+            addBtn.textContent = "Adding…";
+            try {
+              await saveImageToFirebase(url, folder, "", "submission-image");
+              addImageToGallery(url, folder, "", "submission-image", Date.now());
+              updateFolderCounts();
+              addBtn.textContent = "Added";
+              folderSelectEl.disabled = true;
+            } catch (error) {
+              console.error("Error adding submitted image:", error);
+              addBtn.disabled = false;
+              addBtn.textContent = "Add";
+              alert(`Error adding image: ${error.message}`);
+            }
+          });
+          item.appendChild(addBtn);
+
+          imagesWrap.appendChild(item);
+        });
+        row.appendChild(imagesWrap);
+      }
+
+      const dismissBtn = document.createElement("button");
+      dismissBtn.type = "button";
+      dismissBtn.className = "submission-dismiss-btn";
+      dismissBtn.textContent = "Dismiss";
+      dismissBtn.addEventListener("click", async () => {
+        if (!confirm("Dismiss this submission? This can't be undone.")) return;
+        try {
+          await db.collection("submissions").doc(id).delete();
+          row.remove();
+        } catch (error) {
+          console.error("Error dismissing submission:", error);
+          alert(`Error dismissing submission: ${error.message}`);
+        }
+      });
+      row.appendChild(dismissBtn);
+
+      reviewSubmissionsList.appendChild(row);
+    }
+
+    async function loadSubmissions() {
+      reviewSubmissionsList.innerHTML = "<p class=\"modal-hint\">Loading…</p>";
+      try {
+        const snapshot = await db.collection("submissions").orderBy("timestamp", "desc").get();
+        reviewSubmissionsList.innerHTML = "";
+        if (snapshot.empty) {
+          reviewSubmissionsList.innerHTML = '<p class="modal-hint">No pending submissions.</p>';
+          return;
+        }
+        snapshot.forEach(doc => { renderSubmissionRow(doc.id, doc.data()); });
+      } catch (error) {
+        console.error("Error loading submissions:", error);
+        reviewSubmissionsList.innerHTML = `<p class="modal-hint">Error loading submissions: ${error.message}</p>`;
+      }
+    }
+
+    reviewSubmissionsBtn.addEventListener("click", () => {
+      reviewSubmissionsModal.classList.add("active");
+      loadSubmissions();
+    });
+    closeReviewSubmissionsModalBtn.addEventListener("click", () => { reviewSubmissionsModal.classList.remove("active"); });
+    reviewSubmissionsModal.addEventListener("click", (e) => { if (e.target === reviewSubmissionsModal) reviewSubmissionsModal.classList.remove("active"); });
+
     // Confirm Rename Folder button
     confirmRenameFolderBtn.addEventListener("click", async () => {
       const newName = renameFolderInput.value.trim();
@@ -3288,8 +3581,9 @@ function closeEnlargeModal() {
     return; 
   }
   
-  // Check if admin mode is active
-  const isAdminMode = editButtons[0].style.display === "block";
+  // Check if admin mode is active - the Firestore security rules are the
+  // real enforcement, this is just a friendlier client-side message.
+  const isAdminMode = !!auth.currentUser;
   if (!isAdminMode) {
     alert("You need admin access to upload files.");
     return;
@@ -3899,38 +4193,10 @@ async function completeUpload(imageUrl, folderValue, combinedKeywords, fileName,
       });
     });
 
-   
-document.getElementById("closePreferencesPanelBtn").addEventListener("click", () => { 
-  document.getElementById("preferencesPanel").classList.remove("active"); 
-});
-document.getElementById("applyPreferenceBtn").addEventListener("click", () => {
-  // No password check for now — admin controls are granted as soon as the
-  // panel is applied, regardless of what's typed in the ID field.
-  editButtons.forEach(button => { button.style.display = "block"; });
-  separators.forEach(separator => { separator.style.display = "block"; });
-  document.getElementById("preferencesPanel").classList.remove("active");
-  document.getElementById("userPreference").value = "";
-});
-
    document.addEventListener("DOMContentLoaded", async () => {
   try {
     console.log("DOM loaded, initializing application...");
-    // Hide admin buttons by default
-    const adminButtons = document.querySelectorAll(".sidebar-footer button:not(#adminaccessbtn)");
-    adminButtons.forEach(button => { button.style.display = "none"; });
-    
-    const seps = document.querySelectorAll(".separator");
-    seps.forEach(separator => { separator.style.display = "none"; });
-    
-    // Make sure admin access button is visible
-    const adminBtn = document.getElementById("adminaccessbtn");
-    if (adminBtn) {
-      adminBtn.style.display = "block";
-      console.log("Admin access button displayed");
-    } else {
-      console.error("Could not find admin access button");
-    }
-    
+
     // Initialize the upload dock
     const uploadDock = document.getElementById("uploadDock");
     if (uploadDock) {

--- a/index.html
+++ b/index.html
@@ -96,6 +96,39 @@
   color: var(--text);
 }
 
+/* Submit Reference Button CSS - stacked under About, same footprint so it
+   doesn't need its own clearance from the search bar's padding-right */
+.submit-reference-btn {
+  position: absolute;
+  top: 65px;
+  right: 40px;
+  background-color: rgba(24, 24, 27, 0.35);
+  color: var(--text-faint);
+  border: 1px solid var(--border-color);
+  padding: 8px 16px;
+  border-radius: 12px;
+  font-size: 0.85rem;
+  font-weight: 400;
+  cursor: pointer;
+  width: 120px;
+  text-align: center;
+  z-index: 1200;
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  height: 34px;
+  line-height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.submit-reference-btn:hover {
+  background-color: rgba(32, 32, 36, 0.75);
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+
 /* Updated About Modal with blur effect */
 #aboutModal {
   backdrop-filter: blur(15px);
@@ -1155,6 +1188,7 @@
   .sidebar { padding: 0.6rem; }
   .top-search-bar { left: calc(var(--sidebar-width) + 0.8rem); right: 0.6rem; padding-right: 118px; top: 12px; }
   .about-btn { top: 12px; right: 14px; width: 90px; padding: 8px 10px; font-size: 0.85rem; }
+  .submit-reference-btn { top: 60px; right: 14px; width: 90px; height: 30px; padding: 6px 8px; font-size: 0.75rem; }
   #mainImageSearch { padding: 8px 12px; font-size: 0.85rem; }
   .main-content { padding-left: 0.6rem; padding-right: 0.6rem; padding-top: 70px; }
   .floating-size-panel { right: 12px; bottom: 12px; }
@@ -1168,6 +1202,7 @@
   :root { --sidebar-width: 140px; }
   .top-search-bar { left: calc(var(--sidebar-width) + 0.75rem); right: 0.6rem; padding-right: 100px; }
   .about-btn { width: 78px; right: 10px; padding: 6px 8px; font-size: 0.78rem; }
+  .submit-reference-btn { width: 78px; right: 10px; padding: 5px 6px; font-size: 0.68rem; }
 }
 
 .batch-tag-review-content {
@@ -1255,6 +1290,7 @@
 <body>
 
     <button id="aboutBtn" class="about-btn">About</button>
+    <button id="submitReferenceBtn" class="submit-reference-btn">Submit</button>
 
   <div class="top-search-bar">
     <div class="main-search-container">
@@ -1278,7 +1314,33 @@
   </div>
 </div>
 
-  
+  <!-- MODAL: Submit Reference -->
+  <div class="modal-backdrop" id="submitReferenceModal">
+    <div class="modal-content">
+      <button class="close-modal-btn" id="closeSubmitReferenceModalBtn">&times;</button>
+      <h3>Submit a Reference</h3>
+      <p style="margin-bottom: 0.8rem; opacity: 0.8;">Got a Google Drive link or some images to share? Send them here - no need to look up an email address.</p>
+
+      <label for="submitReferenceLink">Link (optional):</label>
+      <input type="url" id="submitReferenceLink" placeholder="https://drive.google.com/...">
+
+      <label for="submitReferenceFiles">Images (optional):</label>
+      <input type="file" id="submitReferenceFiles" accept="image/*" multiple>
+      <div id="submitReferenceFileHint" class="modal-hint">No files selected</div>
+      <div id="submitReferenceFilePreview" class="file-preview-list"></div>
+
+      <label for="submitReferenceNote">Note (optional):</label>
+      <input type="text" id="submitReferenceNote" placeholder="Anything we should know?">
+
+      <div id="submitReferenceStatus" class="modal-hint" style="display:none;"></div>
+
+      <div style="margin-top:0.8rem;">
+        <button id="confirmSubmitReferenceBtn">Send</button>
+      </div>
+    </div>
+  </div>
+
+
   <!-- MAIN CONTAINER (Sidebar + Main Content) -->
   <div class="main-container">
     <!-- SIDEBAR -->
@@ -1730,6 +1792,127 @@ aboutModal.addEventListener("click", (e) => {
     aboutModal.classList.remove("active");
   }
 });
+
+    /********************************************************
+     * Submit Reference (public - not admin-gated)
+     * Lets anyone send a link and/or images without needing an email
+     * address. Stored in its own 'submissions' Firestore collection,
+     * separate from 'images'/'folders', so nothing shows up in the public
+     * gallery until reviewed and added deliberately through Add Image.
+     ********************************************************/
+    const submitReferenceBtn = document.getElementById("submitReferenceBtn");
+    const submitReferenceModal = document.getElementById("submitReferenceModal");
+    const closeSubmitReferenceModalBtn = document.getElementById("closeSubmitReferenceModalBtn");
+    const submitReferenceLink = document.getElementById("submitReferenceLink");
+    const submitReferenceFiles = document.getElementById("submitReferenceFiles");
+    const submitReferenceFileHint = document.getElementById("submitReferenceFileHint");
+    const submitReferenceFilePreview = document.getElementById("submitReferenceFilePreview");
+    const submitReferenceNote = document.getElementById("submitReferenceNote");
+    const submitReferenceStatus = document.getElementById("submitReferenceStatus");
+    const confirmSubmitReferenceBtn = document.getElementById("confirmSubmitReferenceBtn");
+
+    submitReferenceBtn.addEventListener("click", () => {
+      submitReferenceModal.classList.add("active");
+    });
+
+    closeSubmitReferenceModalBtn.addEventListener("click", () => {
+      submitReferenceModal.classList.remove("active");
+    });
+
+    submitReferenceModal.addEventListener("click", (e) => {
+      if (e.target === submitReferenceModal) {
+        submitReferenceModal.classList.remove("active");
+      }
+    });
+
+    // Mirrors the Add Image modal's file preview (thumbnail + count) so
+    // people can confirm what they're about to send.
+    function updateSubmitReferenceFilePreview() {
+      submitReferenceFilePreview.innerHTML = "";
+      const files = Array.from(submitReferenceFiles.files || []);
+      if (files.length === 0) {
+        submitReferenceFileHint.textContent = "No files selected";
+        return;
+      }
+      submitReferenceFileHint.textContent = files.length === 1 ? "1 image selected" : `${files.length} images selected`;
+      files.forEach(file => {
+        const item = document.createElement("div");
+        item.className = "file-preview-item";
+        const thumb = document.createElement("img");
+        thumb.src = URL.createObjectURL(file);
+        thumb.onload = () => URL.revokeObjectURL(thumb.src);
+        thumb.alt = file.name;
+        const label = document.createElement("span");
+        label.textContent = file.name;
+        label.title = file.name;
+        item.appendChild(thumb);
+        item.appendChild(label);
+        submitReferenceFilePreview.appendChild(item);
+      });
+    }
+    submitReferenceFiles.addEventListener("change", updateSubmitReferenceFilePreview);
+
+    function showSubmitReferenceStatus(message, isError) {
+      submitReferenceStatus.textContent = message;
+      submitReferenceStatus.style.display = "block";
+      submitReferenceStatus.style.color = isError ? "var(--danger)" : "var(--success)";
+    }
+
+    function resetSubmitReferenceForm() {
+      submitReferenceLink.value = "";
+      submitReferenceNote.value = "";
+      submitReferenceFiles.value = "";
+      submitReferenceFilePreview.innerHTML = "";
+      submitReferenceFileHint.textContent = "No files selected";
+      submitReferenceStatus.style.display = "none";
+      submitReferenceStatus.textContent = "";
+    }
+
+    async function submitReference() {
+      const linkValue = submitReferenceLink.value.trim();
+      const noteValue = submitReferenceNote.value.trim();
+      const files = Array.from(submitReferenceFiles.files || []);
+
+      if (!linkValue && files.length === 0) {
+        showSubmitReferenceStatus("Please add a link or at least one image.", true);
+        return;
+      }
+
+      confirmSubmitReferenceBtn.disabled = true;
+      showSubmitReferenceStatus("Sending...", false);
+
+      try {
+        const imageUrls = [];
+        // Uploaded one at a time, not in parallel - concurrent multi-MB
+        // uploads racing over the same bandwidth is what caused the admin
+        // upload dock's "Unexpected end of form" bug; same risk applies here.
+        for (const file of files) {
+          const uploadFile = await compressImageIfNeeded(file);
+          const url = await uploadImage(uploadFile);
+          imageUrls.push(url);
+        }
+
+        await db.collection('submissions').add({
+          link: linkValue,
+          imageUrls: imageUrls,
+          note: noteValue,
+          timestamp: firebase.firestore.FieldValue.serverTimestamp(),
+          addTime: Date.now()
+        });
+
+        showSubmitReferenceStatus("Thanks! Your submission was received.", false);
+        setTimeout(() => {
+          resetSubmitReferenceForm();
+          submitReferenceModal.classList.remove("active");
+        }, 1800);
+      } catch (error) {
+        console.error('Error saving submission:', error);
+        showSubmitReferenceStatus(`Something went wrong: ${error.message}`, true);
+      } finally {
+        confirmSubmitReferenceBtn.disabled = false;
+      }
+    }
+    confirmSubmitReferenceBtn.addEventListener("click", submitReference);
 
     /********************************************************
      * Netlify Upload Function

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
 .about-btn {
   position: absolute;
   top: 15px;
-  right: 40px;
+  right: 24px;
   background-color: rgba(24, 24, 27, 0.45);
   color: var(--text-muted);
   border: 1px solid var(--border-color);
@@ -102,7 +102,7 @@
 .submit-reference-btn {
   position: absolute;
   top: 15px;
-  right: 172px;
+  right: 168px;
   background-color: rgba(24, 24, 27, 0.45);
   color: var(--text-muted);
   border: 1px solid var(--border-color);
@@ -435,6 +435,16 @@
   flex-wrap: wrap;
   gap: var(--gallery-gap);
   width: 100%;
+}
+
+.empty-folder-message {
+  display: none;
+  width: 100%;
+  text-align: center;
+  color: var(--text-faint);
+  font-size: 0.85rem;
+  opacity: 0.7;
+  margin-top: 15vh;
 }
 
 .image-container {
@@ -860,13 +870,22 @@
 }
 
 .enlarge-spinner {
+  /* Fixed to the viewport rather than centered within its flex parent -
+     that parent shrinks to near-zero size while the image is still
+     loading, and a stray auto-margin on a sibling (.enlarged-tags-container)
+     could pull the centering off anyway. Viewport-fixed sidesteps both. */
   display: none;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   width: 36px;
   height: 36px;
   border: 3px solid rgba(255, 255, 255, 0.25);
   border-top-color: #fff;
   border-radius: 50%;
   animation: enlarge-spin 0.8s linear infinite;
+  z-index: 15001;
 }
 
 .enlarge-spinner.active {
@@ -898,6 +917,40 @@
 
 .enlarged-download-btn:hover {
   opacity: 0.88;
+}
+
+.enlarge-nav-btn {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: 1px solid rgba(255,255,255,0.18);
+  background-color: rgba(20,20,24,0.55);
+  color: var(--text);
+  font-size: 1.8rem;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 15001;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+.enlarge-nav-btn:hover {
+  background-color: rgba(40,40,46,0.8);
+  border-color: rgba(255,255,255,0.35);
+}
+.enlarge-nav-prev { left: 20px; }
+.enlarge-nav-next { right: 20px; }
+
+@media (max-width: 640px) {
+  .enlarge-nav-btn { width: 38px; height: 38px; font-size: 1.4rem; }
+  .enlarge-nav-prev { left: 8px; }
+  .enlarge-nav-next { right: 8px; }
 }
 
 
@@ -952,13 +1005,14 @@
   position: absolute;
   top: 15px;
   /* Fills the full width between the sidebar and the About/Submit button
-     pair, each kept as an explicit margin (left / padding-right below)
-     rather than centering a fixed-width pill with empty space on both
-     sides. padding-right covers both buttons (Submit sits just left of
-     About - see .submit-reference-btn's `right`) plus a clear gap. */
-  left: calc(var(--sidebar-width) + 1.2rem);
-  right: 0.8rem;
-  padding-right: 310px;
+     pair. The same 24px unit is used for all four gaps in this row: sidebar
+     to search bar (left), search bar to Submit (padding-right minus the
+     button pair's width), Submit to About (see .submit-reference-btn's
+     `right`), and About to the viewport edge (.about-btn's `right`) - so
+     the margins around this whole row read as consistent, not ad hoc. */
+  left: calc(var(--sidebar-width) + 24px);
+  right: 24px;
+  padding-right: 288px;
   z-index: 1000;
   display: flex;
   justify-content: center;
@@ -1191,9 +1245,12 @@
 -------------------------------------------------- */
 @media (max-width: 900px) {
   :root { --sidebar-width: 230px; }
-  .top-search-bar { padding-right: 230px; }
-  .about-btn { width: 90px; padding: 8px 10px; font-size: 0.85rem; }
-  .submit-reference-btn { width: 90px; right: 138px; padding: 8px 10px; font-size: 0.85rem; }
+  /* Same equal-gap approach as the base rule above, just a smaller 20px
+     unit: left, padding-right, Submit-About gap, and About's own `right`
+     are all derived from it. */
+  .top-search-bar { left: calc(var(--sidebar-width) + 20px); right: 20px; padding-right: 220px; }
+  .about-btn { right: 20px; width: 90px; padding: 8px 10px; font-size: 0.85rem; }
+  .submit-reference-btn { right: 130px; width: 90px; padding: 8px 10px; font-size: 0.85rem; }
   #mainImageSearch { padding: 8px 12px; font-size: 0.85rem; }
 }
 
@@ -1205,9 +1262,10 @@
 @media (max-width: 640px) {
   :root { --sidebar-width: 200px; }
   .sidebar { padding: 0.6rem; }
-  .top-search-bar { left: calc(var(--sidebar-width) + 0.8rem); right: 0.6rem; padding-right: 206px; top: 12px; }
-  .about-btn { top: 12px; right: 14px; width: 90px; padding: 8px 10px; font-size: 0.85rem; }
-  .submit-reference-btn { top: 12px; right: 112px; width: 90px; height: 40px; padding: 8px 10px; font-size: 0.85rem; }
+  /* 16px unit for this tier - same equal-gap approach as the wider tiers. */
+  .top-search-bar { left: calc(var(--sidebar-width) + 16px); right: 16px; padding-right: 212px; top: 12px; }
+  .about-btn { top: 12px; right: 16px; width: 90px; padding: 8px 10px; font-size: 0.85rem; }
+  .submit-reference-btn { top: 12px; right: 122px; width: 90px; height: 40px; padding: 8px 10px; font-size: 0.85rem; }
   #mainImageSearch { padding: 8px 12px; font-size: 0.85rem; }
   .main-content { padding-left: 0.6rem; padding-right: 0.6rem; padding-top: 70px; }
   .floating-size-panel { right: 12px; bottom: 12px; }
@@ -1221,10 +1279,16 @@
    hard-to-tap size. */
 @media (max-width: 420px) {
   :root { --sidebar-width: 140px; }
-  .top-search-bar { left: calc(var(--sidebar-width) + 0.75rem); right: 0.6rem; padding-right: 10px; }
-  .about-btn { top: 54px; width: 78px; right: 10px; padding: 6px 8px; font-size: 0.78rem; }
-  .submit-reference-btn { top: 54px; width: 78px; right: 94px; padding: 6px 8px; font-size: 0.78rem; }
-  .main-content { padding-top: 96px; }
+  /* 12px unit: search bar's own left/right margins, and the Submit+About
+     row's left gap (via About/Submit `right`) and their shared gap, all
+     match - the button row just sits on a second line here instead of
+     sharing the search bar's row. `right` alone (not also padding-right,
+     which would stack on top of it) sets the right margin, matching how
+     `left` alone sets the left margin. */
+  .top-search-bar { left: calc(var(--sidebar-width) + 12px); right: 0; padding-right: 12px; }
+  .about-btn { top: 60px; width: 78px; right: 12px; padding: 6px 8px; font-size: 0.78rem; }
+  .submit-reference-btn { top: 60px; width: 78px; right: 102px; padding: 6px 8px; font-size: 0.78rem; }
+  .main-content { padding-top: 100px; }
 }
 
 .batch-tag-review-content {
@@ -1306,61 +1370,71 @@
    Review Submissions Panel
 -------------------------------------------------- */
 .submissions-review-content {
-  max-width: 820px;
+  /* Capped at 840px rather than wider - .sidebar has a higher z-index than
+     .modal-backdrop (a pre-existing mismatch, not introduced here), so a
+     modal wide enough to visually extend under the sidebar has that
+     overlapping strip's clicks swallowed by the sidebar instead of
+     reaching the modal underneath. 840px clears the 270px sidebar even at
+     a 1400px-wide viewport; the extra breathing room in this panel mostly
+     comes from the padding/gap increases below, not from raw width anyway. */
+  max-width: 840px;
+  padding: 1.6rem 2rem 2rem;
 }
 #reviewSubmissionsList {
-  max-height: 65vh;
+  max-height: 70vh;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 22px;
+  padding-right: 4px; /* clears the scrollbar so it doesn't sit flush against row borders */
 }
 .submission-row {
   border: 1px solid var(--border-color);
-  border-radius: var(--radius-sm);
-  padding: 10px;
+  border-radius: var(--radius-md);
+  padding: 20px 22px;
   background: var(--bg-sunken);
 }
 .submission-meta {
-  font-size: 0.78rem;
+  font-size: 0.82rem;
   color: var(--text-faint);
-  margin-bottom: 6px;
+  margin-bottom: 10px;
 }
 .submission-link {
   display: block;
-  font-size: 0.88rem;
-  margin-bottom: 6px;
+  font-size: 0.95rem;
+  margin-bottom: 10px;
   word-break: break-all;
   color: var(--accent);
 }
 .submission-note {
-  font-size: 0.88rem;
-  margin-bottom: 8px;
+  font-size: 0.95rem;
+  margin-bottom: 16px;
   color: var(--text-muted);
+  line-height: 1.5;
 }
 .submission-images {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
-  margin-bottom: 8px;
+  gap: 18px;
+  margin-bottom: 16px;
 }
 .submission-image-item {
-  width: 104px;
+  width: 148px;
 }
 .submission-image-item img {
-  width: 104px;
-  height: 104px;
+  width: 148px;
+  height: 148px;
   object-fit: cover;
-  border-radius: var(--radius-xs);
+  border-radius: var(--radius-sm);
   border: 1px solid var(--border-color);
   display: block;
-  margin-bottom: 4px;
+  margin-bottom: 8px;
 }
 .submission-image-item select {
   width: 100%;
-  font-size: 0.72rem;
-  padding: 2px 4px;
-  margin-bottom: 4px;
+  font-size: 0.8rem;
+  padding: 5px 6px;
+  margin-bottom: 8px;
   background-color: var(--bg-elevated);
   color: var(--text);
   border: 1px solid var(--border-color);
@@ -1368,8 +1442,8 @@
 }
 .submission-image-item button {
   width: 100%;
-  font-size: 0.72rem;
-  padding: 3px 4px;
+  font-size: 0.8rem;
+  padding: 6px 8px;
 }
 .submission-image-item button:disabled {
   opacity: 0.6;
@@ -1377,6 +1451,7 @@
 }
 .submission-dismiss-btn {
   background-color: var(--danger) !important;
+  margin-top: 4px;
 }
 
   </style>
@@ -1480,7 +1555,7 @@
         </div>
         <hr class="separator">
        <div class="sidebar-admin-section">
-  <button id="adminaccessbtn" class="admin-access-btn">ADMIN ACCESS</button>
+  <button id="adminaccessbtn" class="admin-access-btn">Admin Log In</button>
 </div>
       </div>
     </div>
@@ -1499,6 +1574,7 @@
     <!-- MAIN CONTENT -->
     <div class="main-content">
       <div class="gallery" id="gallery"></div>
+      <p id="emptyFolderMessage" class="empty-folder-message">Nothing here for now</p>
     </div>
   </div>
   <!-- FLOATING SIZE PANEL -->
@@ -1515,6 +1591,8 @@
 
   
  <div id="enlargeImageModal">
+  <button id="enlargePrevBtn" class="enlarge-nav-btn enlarge-nav-prev" aria-label="Previous image" type="button">&#8249;</button>
+  <button id="enlargeNextBtn" class="enlarge-nav-btn enlarge-nav-next" aria-label="Next image" type="button">&#8250;</button>
   <div class="enlarged-image-container">
     <div class="enlarge-spinner" id="enlargeSpinner"></div>
     <img id="enlargeImage" src="" alt="">
@@ -1596,7 +1674,7 @@
     <div class="modal-content batch-tag-review-content">
       <button class="close-modal-btn" id="closeEditTagsModalBtn">&times;</button>
       <h3>Edit Tags <span id="editTagsCount"></span></h3>
-      <p style="margin-bottom: 0.8rem;">These tags replace the current tags on every image selected below.</p>
+      <p style="margin-bottom: 0.8rem;">If every image below already shares the same tags, this replaces them. Otherwise, whatever you type here is added to each image's own existing tags.</p>
       <div id="editTagsThumbs" class="batch-review-thumbs-strip"></div>
       <input type="text" id="editTagsInput" class="batch-review-tags-input" placeholder="Edit or add tags...">
       <div style="margin-top:0.8rem;">
@@ -1618,7 +1696,7 @@
   <div class="modal-content submissions-review-content">
     <button class="close-modal-btn" id="closeReviewSubmissionsModalBtn">&times;</button>
     <h3>Review Submissions</h3>
-    <p style="margin-bottom: 0.8rem;">Links and images sent in through the public "Submit" button. Add whichever images are worth keeping to a folder, then dismiss the submission.</p>
+    <p style="margin-bottom: 1.4rem;">Links and images sent in through the public "Submit" button. Add whichever images are worth keeping to a folder, then dismiss the submission.</p>
     <div id="reviewSubmissionsList"></div>
   </div>
 </div>
@@ -1662,6 +1740,12 @@
     }
     const db = firebase.firestore();
     const auth = firebase.auth();
+    // Session-only persistence: signs out automatically when the tab/browser
+    // is closed, rather than Firebase's LOCAL default which survives that.
+    // A same-tab refresh still keeps the session (sessionStorage survives
+    // reload, just not closing the tab) - only closing/quitting logs out.
+    auth.setPersistence(firebase.auth.Auth.Persistence.SESSION)
+      .catch(error => console.warn('Could not set auth persistence:', error));
 
     // Initial variables
     let folders = [
@@ -1678,12 +1762,20 @@
       "wood"
     ];
     let currentFolderFilter = "all";
+    // The .image-container currently open in the lightbox, so the prev/next
+    // arrows know where they are within the currently visible gallery order.
+    let currentEnlargedContainer = null;
     let isDeleteMode = false;
     let selectedImages = [];
     let isMoveMode = false;
     let selectedImagesForMove = [];
     let isTagEditMode = false;
     let selectedImagesForTagEdit = [];
+    // Set by populateEditTagsModal(): whether every selected image already
+    // shared the exact same tags at the moment the modal opened. Determines
+    // whether Save replaces (matched) or adds to each image's own existing
+    // tags (mismatched) - see saveEditedTags().
+    let editTagsAllMatched = true;
     // Batch tag review: images that finished uploading + tagging, awaiting the
     // single end-of-batch review screen
     let batchReviewItems = [];
@@ -1795,7 +1887,7 @@
     closeAdminLoginModalBtn.addEventListener("click", () => { adminLoginModal.classList.remove("active"); });
     adminLoginModal.addEventListener("click", (e) => { if (e.target === adminLoginModal) { adminLoginModal.classList.remove("active"); } });
 
-    adminLoginBtn.addEventListener("click", async () => {
+    async function attemptAdminSignIn() {
       const email = adminEmailInput.value.trim();
       const password = adminPasswordInput.value;
       adminLoginError.style.display = "none";
@@ -1810,9 +1902,23 @@
         adminPasswordInput.value = "";
         adminLoginModal.classList.remove("active");
       } catch (error) {
-        adminLoginError.textContent = `Sign in failed: ${error.message}`;
+        // Deliberately vague - doesn't confirm/deny whether the email is a
+        // real account, just whether these particular credentials worked.
+        adminLoginError.textContent = "Are you really the admin?";
         adminLoginError.style.display = "block";
       }
+    }
+    adminLoginBtn.addEventListener("click", attemptAdminSignIn);
+
+    // Enter submits from either field, so signing in doesn't require
+    // reaching for the mouse.
+    [adminEmailInput, adminPasswordInput].forEach(input => {
+      input.addEventListener("keydown", (e) => {
+        if (e.key === "Enter") {
+          e.preventDefault();
+          attemptAdminSignIn();
+        }
+      });
     });
 
     // The single source of truth for whether admin controls show - fires
@@ -1823,7 +1929,7 @@
       const isSignedIn = !!user;
       editButtons.forEach(button => { button.style.display = isSignedIn ? "block" : "none"; });
       separators.forEach(separator => { separator.style.display = isSignedIn ? "block" : "none"; });
-      adminAccessBtn.textContent = isSignedIn ? "SIGN OUT" : "ADMIN ACCESS";
+      adminAccessBtn.textContent = isSignedIn ? "SIGN OUT" : "Admin Log In";
       adminAccessBtn.style.display = "block";
     });
 
@@ -1849,6 +1955,15 @@
       const containers = [...gallery.children].filter(
         el => getComputedStyle(el).display !== "none"
       );
+
+      // Shown whenever the current folder/search has nothing visible -
+      // checked here since layoutGallery() already runs after every filter,
+      // search, delete, move, and add.
+      const emptyMessage = document.getElementById("emptyFolderMessage");
+      if (emptyMessage) {
+        emptyMessage.style.display = containers.length === 0 ? "block" : "none";
+      }
+
       // getBoundingClientRect() (fractional) is used instead of clientWidth
       // (integer, rounded) — clientWidth can round up half a pixel above the
       // width the flex layout engine actually wraps against, which was
@@ -2165,13 +2280,20 @@ aboutModal.addEventListener("click", (e) => {
       }
     }
 
-    // Netlify's upload function (busboy) reliably fails on raw HEIC/HEIF uploads
-    // regardless of size ("Unexpected end of form"), so those always get converted
-    // to JPEG below. Separately, Netlify Functions reject request bodies over
-    // ~6MB (base64-encoding binary uploads in transit inflates size by ~33% first),
-    // so anything still oversized after that gets re-encoded too, lowering quality
-    // (not pixel dimensions) until it fits, so full-resolution camera photos don't 500.
-    async function compressImageIfNeeded(file, maxBytes = 4.5 * 1024 * 1024) {
+    // Every upload is rescaled to a max of ~1.5MB, regardless of source size -
+    // there's no reason to keep a 20MB camera original around when Cloudinary
+    // serves it back down to 1200/1920px for display anyway. Separately (and
+    // independent of size), HEIC/HEIF always gets converted to JPEG too, since
+    // Netlify's upload function can't reliably accept raw HEIC bytes at all
+    // ("Unexpected end of form") - don't gate that path behind the size check.
+    //
+    // To lose as little visible quality as possible for a given target size,
+    // quality is reduced first at the image's original resolution (see
+    // encodeCanvasUnderSize below) - only once quality alone can't hit the
+    // target does resolution actually shrink, since a huge photo stepped down
+    // to a more reasonable size at decent quality looks better than the same
+    // photo at full resolution crushed to a very low quality.
+    async function compressImageIfNeeded(file, maxBytes = 1.5 * 1024 * 1024) {
       const isHeic = await isHeicFile(file);
       if (!isHeic && file.size <= maxBytes) return file;
 
@@ -2189,12 +2311,8 @@ aboutModal.addEventListener("click", (e) => {
           canvas = await decodeToCanvas(pngBlob);
         }
 
-        let quality = 0.92;
-        let blob = await new Promise(resolve => canvas.toBlob(resolve, 'image/jpeg', quality));
-        while (blob && blob.size > maxBytes && quality > 0.4) {
-          quality -= 0.1;
-          blob = await new Promise(resolve => canvas.toBlob(resolve, 'image/jpeg', quality));
-        }
+        const result = await encodeCanvasUnderSize(canvas, maxBytes);
+        const blob = result && result.blob;
 
         // For non-HEIC files this re-encode is purely a size optimization, so
         // skip it if it didn't actually help. HEIC always takes the converted
@@ -2203,12 +2321,50 @@ aboutModal.addEventListener("click", (e) => {
         if (!blob) return file;
         if (!isHeic && blob.size >= file.size) return file;
 
-        console.log(`Compressed ${file.name}: ${(file.size / 1024 / 1024).toFixed(1)}MB -> ${(blob.size / 1024 / 1024).toFixed(1)}MB (quality ${quality.toFixed(1)})`);
+        console.log(`Compressed ${file.name}: ${(file.size / 1024 / 1024).toFixed(2)}MB -> ${(blob.size / 1024 / 1024).toFixed(2)}MB (quality ${result.quality.toFixed(2)}, ${result.width}x${result.height})`);
         const compressedName = file.name.replace(/\.[^./]+$/, '') + '.jpg';
         return new File([blob], compressedName, { type: 'image/jpeg' });
       } catch (err) {
         console.warn(`Could not compress ${file.name}, uploading original:`, err);
         return file;
+      }
+    }
+
+    // Encodes a canvas as JPEG under maxBytes, preferring lower quality over
+    // smaller dimensions: sweeps quality downward at the current size first,
+    // and only shrinks the canvas itself (redrawn onto a smaller one, then
+    // the quality sweep restarts) once quality alone - down to MIN_QUALITY -
+    // still isn't enough. Gives up and returns the smallest/lowest-quality
+    // attempt made if MIN_DIMENSION would be crossed, rather than degrading
+    // the image indefinitely.
+    async function encodeCanvasUnderSize(canvas, maxBytes) {
+      const MIN_QUALITY = 0.5;
+      const QUALITY_STEP = 0.08;
+      const SCALE_STEP = 0.85;
+      const MIN_DIMENSION = 800;
+
+      let workingCanvas = canvas;
+
+      while (true) {
+        let smallestAtThisSize = null;
+        for (let quality = 0.92; quality >= MIN_QUALITY; quality -= QUALITY_STEP) {
+          const blob = await new Promise(resolve => workingCanvas.toBlob(resolve, 'image/jpeg', quality));
+          if (!blob) break;
+          smallestAtThisSize = { blob, quality, width: workingCanvas.width, height: workingCanvas.height };
+          if (blob.size <= maxBytes) return smallestAtThisSize;
+        }
+
+        const nextWidth = Math.round(workingCanvas.width * SCALE_STEP);
+        const nextHeight = Math.round(workingCanvas.height * SCALE_STEP);
+        if (nextWidth < MIN_DIMENSION || nextHeight < MIN_DIMENSION) {
+          return smallestAtThisSize;
+        }
+
+        const scaledCanvas = document.createElement('canvas');
+        scaledCanvas.width = nextWidth;
+        scaledCanvas.height = nextHeight;
+        scaledCanvas.getContext('2d').drawImage(workingCanvas, 0, 0, nextWidth, nextHeight);
+        workingCanvas = scaledCanvas;
       }
     }
 
@@ -2413,7 +2569,7 @@ aboutModal.addEventListener("click", (e) => {
         // `keywords` param - Edit Tags updates data-keywords in place, and
         // this param would otherwise keep showing whatever the image had
         // when it was first added to the gallery.
-        enlargeImage(url, filename, container.getAttribute('data-keywords') || '');
+        enlargeImage(url, filename, container.getAttribute('data-keywords') || '', container);
       });
 
 // Replace your existing download link creation code with this:
@@ -2966,9 +3122,14 @@ downloadLink.addEventListener("click", function(e) {
       editTagsModal.classList.add("active");
     }
 
-    // Shows a thumbnail per selected image plus a single shared tags field -
-    // saving applies that one value to every selected image at once, the
-    // same way Move Images applies one destination folder to all of them.
+    // Shows a thumbnail per selected image plus a single shared tags field.
+    // When every selected image already has the exact same tags, the field
+    // is prefilled with that value and Save replaces it (same "one value ->
+    // all selected" shape as Move Images' destination picker). When they
+    // don't match, the field starts blank and Save instead *adds* whatever
+    // is typed to each image's own existing tags - each image keeps its own
+    // previous tags rather than having them overwritten by a value that was
+    // never shown for that particular image.
     function populateEditTagsModal() {
       editTagsThumbs.innerHTML = "";
       editTagsCount.textContent = `(${selectedImagesForTagEdit.length})`;
@@ -2980,20 +3141,47 @@ downloadLink.addEventListener("click", function(e) {
         editTagsThumbs.appendChild(thumb);
       });
 
-      // Only prefill when every selected image already shares the exact same
-      // tags - otherwise leave it blank so saving can't silently overwrite
-      // tags on images the user never actually looked at.
       const currentTags = selectedImagesForTagEdit.map(c => c.getAttribute("data-keywords") || "");
-      const allSame = currentTags.every(t => t === currentTags[0]);
-      editTagsInput.value = allSame ? currentTags[0] : "";
+      editTagsAllMatched = currentTags.every(t => t === currentTags[0]);
+      editTagsInput.value = editTagsAllMatched ? currentTags[0] : "";
+      editTagsInput.placeholder = editTagsAllMatched
+        ? "Edit or add tags..."
+        : "Add tags to every selected image...";
+    }
+
+    // Combines two comma-separated tag strings, dropping case-insensitive
+    // duplicates rather than appending a tag an image already has again.
+    function mergeTagStrings(existingTags, addedTags) {
+      const toList = (s) => s.split(",").map(t => t.trim()).filter(Boolean);
+      const merged = toList(existingTags);
+      const seenLower = new Set(merged.map(t => t.toLowerCase()));
+      toList(addedTags).forEach(tag => {
+        if (!seenLower.has(tag.toLowerCase())) {
+          merged.push(tag);
+          seenLower.add(tag.toLowerCase());
+        }
+      });
+      return merged.join(", ");
     }
 
     async function saveEditedTags() {
       if (selectedImagesForTagEdit.length === 0) return;
-      const newTags = editTagsInput.value.trim();
+      const typedValue = editTagsInput.value.trim();
       try {
         const savePromises = selectedImagesForTagEdit.map(async (container) => {
           const previousTags = container.getAttribute("data-keywords") || "";
+          // Matched: the field held (and may now hold an edited version of)
+          // the one shared value, so Save replaces it outright. Mismatched:
+          // an empty field means nothing to add for this image - leave it
+          // untouched rather than blanking tags the admin never saw.
+          let newTags;
+          if (editTagsAllMatched) {
+            newTags = typedValue;
+          } else if (!typedValue) {
+            return true;
+          } else {
+            newTags = mergeTagStrings(previousTags, typedValue);
+          }
           if (newTags === previousTags) return true; // nothing changed, skip the write
           const imageUrl = container.dataset.url;
           const imageId = await findImageIdByUrl(imageUrl);
@@ -3017,7 +3205,8 @@ downloadLink.addEventListener("click", function(e) {
      * Enlarge Image Modal Closure (click outside image)
      ********************************************************/
 
-  function enlargeImage(url, filename, keywords = "") {
+  function enlargeImage(url, filename, keywords = "", container = null) {
+  currentEnlargedContainer = container;
   const enlargeModal = document.getElementById("enlargeImageModal");
   const enlargeImg = document.getElementById("enlargeImage");
   const enlargeSpinner = document.getElementById("enlargeSpinner");
@@ -3157,19 +3346,57 @@ downloadLink.addEventListener("click", function(e) {
 function closeEnlargeModal() {
   const enlargeModal = document.getElementById("enlargeImageModal");
   const downloadBtn = document.getElementById("enlargedDownloadBtn");
-  
+
   enlargeModal.style.display = "none";
   if (downloadBtn) {
     downloadBtn.style.display = "none";
   }
+  currentEnlargedContainer = null;
 }
 
-    
+
     document.getElementById("enlargeImageModal").addEventListener("click", function(e) {
   if (e.target.id === "enlargeImageModal") {
     closeEnlargeModal();
   }
 });
+
+    // Prev/Next navigation within the lightbox - same visible order (current
+    // filter/search/sort) as the gallery grid itself.
+    function getVisibleGalleryContainers() {
+      return [...gallery.children].filter(el => getComputedStyle(el).display !== "none");
+    }
+
+    function showAdjacentEnlargedImage(direction) {
+      if (!currentEnlargedContainer) return;
+      const visible = getVisibleGalleryContainers();
+      const index = visible.indexOf(currentEnlargedContainer);
+      if (index === -1) return;
+      const nextIndex = (index + direction + visible.length) % visible.length;
+      const nextContainer = visible[nextIndex];
+      const nextImg = nextContainer.querySelector("img");
+      enlargeImage(
+        nextContainer.dataset.url,
+        nextImg.alt,
+        nextContainer.getAttribute("data-keywords") || "",
+        nextContainer
+      );
+    }
+
+    document.getElementById("enlargePrevBtn").addEventListener("click", (e) => {
+      e.stopPropagation();
+      showAdjacentEnlargedImage(-1);
+    });
+    document.getElementById("enlargeNextBtn").addEventListener("click", (e) => {
+      e.stopPropagation();
+      showAdjacentEnlargedImage(1);
+    });
+
+    document.addEventListener("keydown", (e) => {
+      if (document.getElementById("enlargeImageModal").style.display !== "flex") return;
+      if (e.key === "ArrowRight") showAdjacentEnlargedImage(1);
+      else if (e.key === "ArrowLeft") showAdjacentEnlargedImage(-1);
+    });
 
     /********************************************************
      * Event Listeners

--- a/index.html
+++ b/index.html
@@ -1818,9 +1818,11 @@ aboutModal.addEventListener("click", (e) => {
     /********************************************************
      * Submit Reference (public - not admin-gated)
      * Lets anyone send a link and/or images without needing an email
-     * address. Stored in its own 'submissions' Firestore collection,
-     * separate from 'images'/'folders', so nothing shows up in the public
-     * gallery until reviewed and added deliberately through Add Image.
+     * address. Emailed straight to the site owner (see
+     * sendSubmissionEmailNotification below) - not written to Firestore or
+     * the gallery at all, so nothing shows up publicly and there's no
+     * separate place to go check; reviewing and adding anything worth
+     * keeping is entirely manual, through the existing Add Image flow.
      ********************************************************/
     const submitReferenceBtn = document.getElementById("submitReferenceBtn");
     const submitReferenceModal = document.getElementById("submitReferenceModal");
@@ -1893,7 +1895,11 @@ aboutModal.addEventListener("click", (e) => {
     // Best-effort email notification via FormSubmit's AJAX relay - no backend
     // of our own, no API key. isakovicadrien@gmail.com must click the
     // one-time "activate this inbox" email FormSubmit sends on the very
-    // first submission before notifications start arriving.
+    // first submission before notifications start arriving. This email is
+    // the only record of a submission - deliberately not also written to
+    // Firestore, so there isn't a second place to check for these; the site
+    // owner wants to receive them by email and add anything worth keeping
+    // by hand through the existing Add Image flow, nothing automatic.
     // Note this address is visible in the browser's network tab (it's a
     // client-side POST), just never shown anywhere in the page's own UI.
     async function sendSubmissionEmailNotification({ link, imageUrls, note }) {
@@ -1939,26 +1945,7 @@ aboutModal.addEventListener("click", (e) => {
           imageUrls.push(url);
         }
 
-        // Firestore is the durable record and must succeed; the email
-        // notification is best-effort and shouldn't fail the submission if
-        // the relay is down or not yet activated.
-        const [firestoreResult, emailResult] = await Promise.allSettled([
-          db.collection('submissions').add({
-            link: linkValue,
-            imageUrls: imageUrls,
-            note: noteValue,
-            timestamp: firebase.firestore.FieldValue.serverTimestamp(),
-            addTime: Date.now()
-          }),
-          sendSubmissionEmailNotification({ link: linkValue, imageUrls, note: noteValue })
-        ]);
-
-        if (firestoreResult.status === 'rejected') {
-          throw firestoreResult.reason;
-        }
-        if (emailResult.status === 'rejected') {
-          console.warn('Submission saved, but the email notification failed to send:', emailResult.reason);
-        }
+        await sendSubmissionEmailNotification({ link: linkValue, imageUrls, note: noteValue });
 
         showSubmitReferenceStatus("Thanks! Your submission was received.", false);
         setTimeout(() => {
@@ -1966,7 +1953,7 @@ aboutModal.addEventListener("click", (e) => {
           submitReferenceModal.classList.remove("active");
         }, 1800);
       } catch (error) {
-        console.error('Error saving submission:', error);
+        console.error('Error sending submission:', error);
         showSubmitReferenceStatus(`Something went wrong: ${error.message}`, true);
       } finally {
         confirmSubmitReferenceBtn.disabled = false;

--- a/index.html
+++ b/index.html
@@ -68,18 +68,18 @@
   position: absolute;
   top: 15px;
   right: 40px;
-  background-color: rgba(24, 24, 27, 0.65);
-  color: var(--text);
+  background-color: rgba(24, 24, 27, 0.45);
+  color: var(--text-muted);
   border: 1px solid var(--border-color);
   padding: 10px 16px;
   border-radius: 12px;
   font-size: 0.95rem;
-  font-weight: 500;
+  font-weight: 400;
   cursor: pointer;
   width: 120px;
   text-align: center;
   z-index: 1200;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
   height: 40px;
@@ -87,12 +87,13 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: background-color 0.2s ease, border-color 0.2s ease;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
 }
 
 .about-btn:hover {
   background-color: rgba(32, 32, 36, 0.8);
   border-color: var(--border-strong);
+  color: var(--text);
 }
 
 /* Updated About Modal with blur effect */
@@ -915,14 +916,12 @@
 .top-search-bar {
   position: absolute;
   top: 15px;
-  /* Same horizontal insets as .main-content, so this bar lines up with the
-     gallery below it instead of looking randomly narrower. padding-right
-     (not a bigger `right`) reserves room for the About button, so it only
-     nudges where the search pill is centered without shrinking the box
-     itself out of alignment with the gallery. */
-  left: calc(var(--sidebar-width) + 0.8rem);
+  /* Fills the full width between the sidebar and the About button, each
+     kept as an explicit margin (left / padding-right below) rather than
+     centering a fixed-width pill with empty space on both sides. */
+  left: calc(var(--sidebar-width) + 1.2rem);
   right: 0.8rem;
-  padding-right: 160px;
+  padding-right: 180px;
   z-index: 1000;
   display: flex;
   justify-content: center;
@@ -930,8 +929,6 @@
 
 .main-search-container {
   width: 100%;
-  max-width: 700px;
-  margin: 0 auto;
   position: relative;
   border-radius: 12px;
 }
@@ -1156,7 +1153,7 @@
 @media (max-width: 640px) {
   :root { --sidebar-width: 200px; }
   .sidebar { padding: 0.6rem; }
-  .top-search-bar { left: calc(var(--sidebar-width) + 0.6rem); right: 0.6rem; padding-right: 104px; top: 12px; }
+  .top-search-bar { left: calc(var(--sidebar-width) + 0.8rem); right: 0.6rem; padding-right: 118px; top: 12px; }
   .about-btn { top: 12px; right: 14px; width: 90px; padding: 8px 10px; font-size: 0.85rem; }
   #mainImageSearch { padding: 8px 12px; font-size: 0.85rem; }
   .main-content { padding-left: 0.6rem; padding-right: 0.6rem; padding-top: 70px; }
@@ -1169,7 +1166,7 @@
    keeps usable room next to it */
 @media (max-width: 420px) {
   :root { --sidebar-width: 140px; }
-  .top-search-bar { left: calc(var(--sidebar-width) + 0.6rem); right: 0.6rem; padding-right: 88px; }
+  .top-search-bar { left: calc(var(--sidebar-width) + 0.75rem); right: 0.6rem; padding-right: 100px; }
   .about-btn { width: 78px; right: 10px; padding: 6px 8px; font-size: 0.78rem; }
 }
 
@@ -1238,6 +1235,15 @@
   line-height: 1;
 }
 .batch-review-remove:hover { opacity: 0.7; }
+
+.batch-review-thumbs-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  max-height: 30vh;
+  overflow-y: auto;
+  margin-bottom: 0.8rem;
+}
 
   </style>
 
@@ -1428,8 +1434,9 @@
     <div class="modal-content batch-tag-review-content">
       <button class="close-modal-btn" id="closeEditTagsModalBtn">&times;</button>
       <h3>Edit Tags <span id="editTagsCount"></span></h3>
-      <p style="margin-bottom: 0.8rem;">Edit tags for each selected image, then save them all at once.</p>
-      <div id="editTagsList" class="batch-review-list"></div>
+      <p style="margin-bottom: 0.8rem;">These tags replace the current tags on every image selected below.</p>
+      <div id="editTagsThumbs" class="batch-review-thumbs-strip"></div>
+      <input type="text" id="editTagsInput" class="batch-review-tags-input" placeholder="Edit or add tags...">
       <div style="margin-top:0.8rem;">
         <button id="saveEditTagsBtn">Save All</button>
       </div>
@@ -1501,8 +1508,6 @@
     let selectedImagesForMove = [];
     let isTagEditMode = false;
     let selectedImagesForTagEdit = [];
-    // { container, input } pairs for the currently open Edit Tags modal
-    let tagEditRows = [];
     // Batch tag review: images that finished uploading + tagging, awaiting the
     // single end-of-batch review screen
     let batchReviewItems = [];
@@ -1563,7 +1568,8 @@
     const cancelTagEditBtn = document.getElementById("cancelTagEditBtn");
     const editTagsModal = document.getElementById("editTagsModal");
     const closeEditTagsModalBtn = document.getElementById("closeEditTagsModalBtn");
-    const editTagsList = document.getElementById("editTagsList");
+    const editTagsThumbs = document.getElementById("editTagsThumbs");
+    const editTagsInput = document.getElementById("editTagsInput");
     const editTagsCount = document.getElementById("editTagsCount");
     const saveEditTagsBtn = document.getElementById("saveEditTagsBtn");
 
@@ -2572,51 +2578,37 @@ downloadLink.addEventListener("click", function(e) {
         alert("Please select at least one image to edit tags for.");
         return;
       }
-      populateEditTagsList();
+      populateEditTagsModal();
       editTagsModal.classList.add("active");
     }
 
-    // Builds one editable row per selected image, reusing the same
-    // .batch-review-* markup/styling as the upload batch tag review panel.
-    function populateEditTagsList() {
-      editTagsList.innerHTML = "";
+    // Shows a thumbnail per selected image plus a single shared tags field -
+    // saving applies that one value to every selected image at once, the
+    // same way Move Images applies one destination folder to all of them.
+    function populateEditTagsModal() {
+      editTagsThumbs.innerHTML = "";
       editTagsCount.textContent = `(${selectedImagesForTagEdit.length})`;
-      tagEditRows = selectedImagesForTagEdit.map(container => {
-        const row = document.createElement("div");
-        row.className = "batch-review-row";
-
+      selectedImagesForTagEdit.forEach(container => {
         const thumb = document.createElement("img");
         thumb.className = "batch-review-thumb";
         thumb.src = container.querySelector("img").src;
-        row.appendChild(thumb);
-
-        const info = document.createElement("div");
-        info.className = "batch-review-info";
-
-        const filename = document.createElement("div");
-        filename.className = "batch-review-filename";
-        filename.textContent = container.querySelector("img").alt || "image";
-        info.appendChild(filename);
-
-        const tagsInput = document.createElement("input");
-        tagsInput.type = "text";
-        tagsInput.className = "batch-review-tags-input";
-        tagsInput.placeholder = "Edit or add tags...";
-        tagsInput.value = container.getAttribute("data-keywords") || "";
-        info.appendChild(tagsInput);
-
-        row.appendChild(info);
-        editTagsList.appendChild(row);
-
-        return { container, input: tagsInput };
+        thumb.alt = container.querySelector("img").alt || "image";
+        editTagsThumbs.appendChild(thumb);
       });
+
+      // Only prefill when every selected image already shares the exact same
+      // tags - otherwise leave it blank so saving can't silently overwrite
+      // tags on images the user never actually looked at.
+      const currentTags = selectedImagesForTagEdit.map(c => c.getAttribute("data-keywords") || "");
+      const allSame = currentTags.every(t => t === currentTags[0]);
+      editTagsInput.value = allSame ? currentTags[0] : "";
     }
 
     async function saveEditedTags() {
-      if (tagEditRows.length === 0) return;
+      if (selectedImagesForTagEdit.length === 0) return;
+      const newTags = editTagsInput.value.trim();
       try {
-        const savePromises = tagEditRows.map(async ({ container, input }) => {
-          const newTags = input.value.trim();
+        const savePromises = selectedImagesForTagEdit.map(async (container) => {
           const previousTags = container.getAttribute("data-keywords") || "";
           if (newTags === previousTags) return true; // nothing changed, skip the write
           const imageUrl = container.dataset.url;
@@ -2629,7 +2621,6 @@ downloadLink.addEventListener("click", function(e) {
           return false;
         });
         await Promise.all(savePromises);
-        tagEditRows = [];
         editTagsModal.classList.remove("active");
         toggleTagEditMode();
       } catch (error) {


### PR DESCRIPTION
## Summary

Six rounds of related admin/UX work, ending in a real security model for the admin section plus a batch of polish fixes.

**1. Admin: select images, move between folders, edit tags**
- Move Images already existed. Added **Edit Tags**: select images, one shared tags field. If every selected image already has identical tags, Save replaces them; otherwise Save **adds** the typed tag(s) to each image's own existing tags (deduped, case-insensitive) rather than clobbering them with one value never shown for that image.
- Fixed a stale-closure bug so tag edits show up in the lightbox without a reload.
- Made Delete / Move / Edit Tags mutually exclusive (all three select-then-act over the same thumbnails).

**2. Search bar + header buttons**
- Search bar fills the space between the sidebar and header buttons at every width. Submit sits beside About with matching visual weight. All four gaps in that row (sidebar→search bar, search bar→Submit, Submit→About, About→edge) now use one consistent unit per breakpoint instead of ad hoc values.

**3. Public "Submit" button + Review Submissions**
- Visitor-facing form (link, images, note) with no email shown anywhere. Submissions land in a `submissions` Firestore collection specifically to back a new **Review Submissions** admin panel — every pending submission as real thumbnails with a per-image folder picker + Add button, plus Dismiss. Replaces an earlier "email only" design once the real problem became clear: opening 40 individual email links one at a time isn't workable.
- A best-effort email ping to **isakovicadrien@gmail.com** still fires via FormSubmit's relay alongside the Firestore write (fire-and-forget — a failed/slow email can't block or delay the submission).
- **Action needed:** isakovicadrien@gmail.com must click FormSubmit's one-time "activate this inbox" email on the first real submission, or the ping silently never arrives (harmless either way — Firestore is unaffected).

**4. Real admin authentication (Firebase Auth), replacing the no-password gate**
- "Admin Log In" (renamed from "ADMIN ACCESS", becomes "SIGN OUT" once signed in) opens a real email + password sign-in. Enter submits from either field. A failed attempt shows a deliberately vague "Are you really the admin?" rather than leaking which part was wrong. Session persistence is explicit `SESSION` mode — closing the tab/browser signs out automatically; a same-tab refresh keeps the session.
- Real enforcement is **Firestore security rules** (`firestore.rules`, checked in for reference), requiring the authenticated user's email to match the one admin account for any write to `folders`/`images`, and for any read/write to `submissions` (still allows anonymous **create**, so public Submit keeps working without login). The client-side button show/hide is cosmetic only.
- **Action needed (no Firebase project access from this session):**
  1. Firebase Console → Authentication → Sign-in method → enable **Email/Password**.
  2. Firebase Console → Authentication → Users → create **isakovicadrien@gmail.com** + a password.
  3. Firebase Console → Firestore Database → Rules → paste the contents of `firestore.rules`.

**5. Smaller UX fixes**
- Empty folders/searches show small centered "Nothing here for now" text instead of a blank area.
- Lightbox gained prev/next navigation — left/right arrow keys or new on-screen arrow buttons — walking the currently visible/filtered gallery order, wrapping at the ends.
- Lightbox's loading spinner is pinned to the viewport center (was drifting toward the top while the image was still loading, due to a flex/auto-margin interaction with a sibling element).
- Review Submissions got more breathing room (padding, gaps, bigger thumbnails); width is deliberately capped at 840px since wider ran the modal under the sidebar (which has a higher z-index than modals) and started swallowing clicks meant for the modal itself.

**6. Uploads rescaled to a 1.5MB max**
- Every upload (was ~4.5MB threshold) now gets rescaled to ~1.5MB, preferring a quality-only reduction at full resolution first (`encodeCanvasUnderSize()`) and only shrinking dimensions if quality alone can't hit the target — a huge photo stepped down to a still-generous resolution at good quality looks better than the same photo crushed to very low quality at full size.

`CLAUDE.md` and `firestore.rules` updated throughout to document all of this for future sessions.

## Test plan

- [x] `npm test` — unaffected, still passing throughout every round.
- [x] `node --check` on the extracted inline `<script>` after every round.
- [x] Playwright against a local static server, with `window.firebase` stubbed (including a fake `auth()`) since CDN/Firebase/FormSubmit egress is blocked in this sandbox:
  - Edit Tags: matched-mode replace and mismatched-mode add+dedupe both verified, including a case that adds an already-present tag (confirmed not duplicated).
  - Auth: buttons hidden until sign-in; wrong credentials show the exact vague message and stay logged out; correct credentials sign in and flip the button; sign-out reverts everything; `setPersistence(SESSION)` confirmed called.
  - Review Submissions: loads seeded submissions with thumbnails, adds an image to a chosen folder (appears in gallery immediately), Dismiss deletes the Firestore doc — including catching and fixing a real regression where a wider modal overlapped the sidebar and swallowed the Dismiss click.
  - Lightbox: arrow keys and on-screen buttons both navigate and wrap correctly; spinner confirmed viewport-centered via computed style.
  - Header margins: numerically verified equal (via `getBoundingClientRect()`) at four different viewport widths, including the sub-420px stacked layout.
  - Compression: a smooth/photo-like large image compresses under 1.5MB via quality alone (dimensions unchanged); an already-small file passes through untouched; a hard-to-compress synthetic image correctly shrinks dimensions (not below the 800px floor) to hit the target.
- [x] Visual screenshots reviewed manually at every step.