### PR TITLE
Fix password-save trigger, sidebar order, color detection accuracy, upload stall; add color filter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,11 +130,55 @@ with admin-only upload/tagging/organizing tools. Deployed on Netlify.
     paths behave identically). The queue is intentionally **not** cleared when the modal is closed
     without publishing — only an explicit Publish All (or a page reload) empties it — so
     accidentally dismissing the modal mid-batch doesn't lose staged work.
+    **Bug fixed the same day, found via real use:** reported as some images in a batch staying
+    stuck at "0%" in the upload dock forever, even though the upload itself was actually going
+    through. Cause: `startUploadBatch()` derived each dock row's DOM id from `Date.now()`
+    (`upload-<uploadBatchId>-<i>`), and Publish All calls `startUploadBatch()` once per queued
+    batch inside a single synchronous `batches.forEach(...)` - multiple batches published together
+    landed in the same millisecond often enough to give two different batches the *same*
+    `uploadBatchId`, so a batch's file at index `i` collided with another batch's file at the same
+    index: two dock rows with identical DOM ids. `document.getElementById()` always resolves to the
+    first matching element, so `setUploadItemProgress()` calls for the second (colliding) batch
+    silently updated the *first* batch's row instead of its own, leaving the second batch's actual
+    row frozen at its initial "0%" template state indefinitely, with no error and no console
+    output - the upload for that file was completing normally the whole time, just invisibly.
+    Fixed by adding a monotonically-incrementing counter (`uploadBatchCounter`) into the id
+    alongside `Date.now()`, guaranteeing uniqueness regardless of how many `startUploadBatch()`
+    calls land in the same millisecond. If another "stuck progress" report shows up, check whether
+    it's this same shape (multiple batches/uploads kicked off synchronously close together) before
+    assuming it's a new bug.
   - **Search now treats the folder/category name as an invisible tag too (2026-07-30)** —
     `performSearch()` matches the search term against `data-category` in addition to filename and
     `data-keywords`, so searching "metal" also surfaces every image filed under a Metal folder (or
     Metal/<subfolder>), on top of images anywhere else explicitly tagged "metal". This only affects
     the top search bar; the sidebar's folder-click filtering (`filterImages()`) is unchanged.
+    **Superseded 2026-07-30, later the same day:** `filterImages()` is no longer purely
+    folder-driven either - see the color filter bullet below.
+  - **Floating color filter panel (2026-07-30)** — a second floating pill panel, stacked directly
+    above the existing size selector (same visual treatment: `.floating-color-panel`/`.color-dot`,
+    modeled on `.floating-size-panel`/`.size-icon`), with one small round swatch per color name the
+    dominant-color auto-tagger can produce (black/white/gray/brown/beige/red/orange/yellow/green/
+    cyan/blue/purple/pink). Clicking a dot filters the gallery to images whose keywords include
+    that color word; clicking the already-selected dot again clears it back to no color filter
+    (single-select, like the size selector). This is the first *third* filter dimension the gallery
+    has had - folder (`currentFolderFilter`) and search text already existed, but neither function
+    that applies them (`filterImages()`, `performSearch()`) called the other or shared any common
+    combining logic, so adding color required touching both rather than composing with an existing
+    mechanism: `imageMatchesColorFilter(container)` is now ANDed onto the show/hide decision in
+    both, via `currentColorFilter` (module-level, null = no filter). Whichever of the two is
+    "active" (search text if non-empty, otherwise the folder filter - `performSearch()` already
+    delegates to `filterImages(currentFolderFilter)` when the search box is empty) still decides
+    the *base* set; color only ever narrows it further, never overrides it. If a future filter
+    dimension gets added, wire it into `imageMatchesColorFilter()`'s pattern (a small
+    `imageMatchesX()` predicate ANDed into both functions) rather than inventing a fourth
+    independent mechanism. Sidebar folder counts (`countImages()`/`updateFolderCounts()`)
+    deliberately do **not** account for the color filter, same as they already didn't account for
+    search text - they show each category's total size regardless of any other active filter.
+    **Images published before this feature (and before the dominant-color auto-tagger two commits
+    earlier) have no color tag at all**, so they won't match any dot until re-tagged (via Edit
+    Tags) or re-published - this was flagged and explicitly accepted rather than backfilling
+    existing images with a detected color, since backfilling would mean loading all ~191 images
+    just to color-tag them, and there was no clear request to do that.
   - **`.sidebar-brand` crop fix (2026-07-30)** — the "aReferences" header text could get silently
     cropped at the bottom (no scrollbar, no error) whenever the sidebar's total content grew taller
     than the viewport, e.g. right after admin sign-in reveals the extra footer buttons. Cause: it
@@ -178,40 +222,70 @@ with admin-only upload/tagging/organizing tools. Deployed on Netlify.
     bold, visually-separated entry above "All" at the top of the sidebar (`.new-this-week` had its
     own `font-size: 1.1rem; font-weight: 600` rule, distinct from ordinary folder items). That
     rule was removed outright rather than adjusted, so it now falls through to the same plain
-    `.folder-list > li` styling every other category uses. It's still the first `<li>` rendered in
-    `renderFolders()` (unchanged), so it's still the first item in the list, just no longer
-    visually shouting above everything else - "All" (which still has its own bold/separator
-    styling) sits directly below it, unchanged.
-  - **Dominant-color auto-tagging (2026-07-30)** — every image that gets published now
-    automatically gets a plain-language color tag (e.g. `brown`, `gray`, `beige`) merged into its
-    keywords via `mergeTagStrings()`, with no admin input required. This is a coarse,
+    `.folder-list > li` styling every other category uses. **Reordered same day, second pass:**
+    initially left as the first `<li>` (above "All"), just smaller - but a normal-looking item
+    still being the very first thing above "All" read as its own kind of visual precedence, so
+    `renderFolders()` now appends "All" first and "New This Week" second, and "All"'s `border-top`
+    separator (originally there to separate it from "New This Week" sitting above it) was removed
+    since "All" is the first item now and has nothing above it to separate from. If either item's
+    position needs to change again, both the DOM order in `renderFolders()` and `.folder-list >
+    li.all`'s styling need checking together - they were designed as a pair.
+  - **Dominant-color auto-tagging (2026-07-30, reworked same day)** — every image that gets
+    published automatically gets a plain-language color tag (e.g. `brown`, `gray`, `beige`) merged
+    into its keywords via `mergeTagStrings()`, with no admin input required. This is a coarse,
     dependency-free heuristic, not anything ML-based (deliberately - see the AI tagging removal
-    note above; this doesn't reintroduce that): `dominantColorNameFromCanvas()` downsamples the
-    image to a 64x64 offscreen canvas, buckets pixels into a coarse histogram (colors quantized to
-    ~24-wide RGB buckets so near-identical shades collapse into one vote instead of splitting),
-    and takes the most-common bucket's average RGB. `nameColorFromRgb()` then maps that RGB to one
-    of a fixed set of names via HSL hue/saturation/lightness thresholds - neutrals (black/white/
-    gray) are checked first since hue is meaningless at extreme lightness or near-zero saturation,
-    then `brown` and `beige` are carved out of the orange hue range by lightness/saturation (common
-    on this gallery's actual content - wood, stone, concrete, rust - where "orange" alone wouldn't
-    be a useful tag), then the remaining hue wheel maps to red/orange/yellow/green/cyan/blue/
-    purple/pink. The thresholds were tuned by hand against a set of sample RGB values run through
-    the classifier directly in Node (not against real photos - there's no live Cloudinary access
-    in a sandboxed session) - if a published image gets an obviously wrong color tag, that's the
-    first place to adjust, and it's worth re-running a similar spot-check rather than guessing at
-    new threshold numbers. There are two call sites, because there are two different sources for
-    the image bytes at "publish" time: `detectDominantColorTag(file)` runs on the local `File`
-    object in the admin upload dock / Publish Queue path (`processUpload()`, in parallel with the
-    network upload itself so it adds no extra wait), while `detectDominantColorTagFromUrl(url)`
-    runs when Review Submissions' "Add" button publishes an image that's already sitting on
-    Cloudinary from the original public submission (no local `File` exists for that path at all -
-    see the Review Submissions note above) by loading a small `w_64` Cloudinary transform into an
-    `<img crossOrigin="anonymous">` and reading it back via canvas; this depends on Cloudinary
-    serving delivery URLs with CORS enabled, which it does by default, but if that were ever not
-    true the canvas read throws (a tainted-canvas security error) and detection just silently
-    returns `null` rather than blocking the Add. Both call sites are try/caught to never fail the
-    publish itself - a failed color detection just means no color tag gets added, same as if
-    nothing had been typed into Keywords.
+    note above; this doesn't reintroduce that). **The first version was wrong in practice and got
+    reworked the same day once real test photos came back badly misclassified** - worth reading
+    before touching this again: it bucketed raw RGB values into a histogram (nearby colors grouped
+    into buckets, most-populated bucket by raw pixel count wins, then that bucket's average color
+    gets named) and consistently picked the wrong region on real photos. A subject's own surface
+    has enough natural lighting variation (highlights, shadow, texture) that its pixels spread
+    across many nearby-but-distinct RGB buckets and split their own vote, while a flatter, more
+    uniform area elsewhere in the frame - a blurred gray floor in one corner, a shadow seam between
+    two wall planes, the dark gaps between leaves in foliage - stays tightly clustered in a couple
+    of buckets and out-votes the actual subject by raw count, even while visibly occupying less of
+    the frame. Confirmed against four real test photos: a yellow chair (blurred gray floor in one
+    corner) came back "gray", a reddish-brown weathered wall came back "gray", a white/gray wall
+    corner with a shadowed seam came back "black", and green foliage (with dark gaps between
+    leaves) came back "black" - background/shadow beating the actual subject in every case. Fixed
+    by reworking `dominantColorNameFromCanvas()` to classify every sampled pixel individually into
+    a color name first (via `nameColorFromRgb()`, unchanged in spirit) and tally votes per *name*
+    instead of per fine-grained RGB bucket - far less sensitive to lighting-driven RGB spread,
+    since a lit vs. shaded patch of the same material usually still names the same hue even when
+    their raw RGB values are nowhere near each other. Pixels below a chroma (max channel - min
+    channel) threshold are excluded from the vote entirely - the exact pixels that were winning
+    before - *unless* almost the whole image is low-chroma, in which case it falls back to voting
+    on every pixel, since that means the image is genuinely neutral (a true black/white/gray
+    material) rather than having its real color filtered out. Also fixed in the same pass:
+    `nameColorFromRgb()`'s own black/white/gray gate used HSL's `s` (saturation), whose formula
+    divides by `(2 - max - min)` near white and `(max + min)` near black - both shrink toward 0 at
+    those extremes, so tiny/insignificant RGB differences (sensor noise, JPEG artifacts) got
+    amplified into misleadingly large "saturation" readings exactly where it mattered most for
+    telling white/black apart from a weak tint (caught via a synthetic "near-white marble" test
+    case classifying as a random hue instead of white). Replaced with a chroma-based gate, which
+    has no such blowup; `s` is still used for the brown/beige lightness carve-out, safely away from
+    those unstable extremes. Verified against ~10 synthetic pixel-population test cases built to
+    mimic these exact failure shapes (a large-but-secondary neutral region alongside a smaller,
+    more-varied colorful subject) directly in Node before landing this - **there's still no live
+    Cloudinary access in a sandboxed session, so none of this has been checked against an actual
+    real uploaded photo end-to-end** - if a published image still gets an obviously wrong color
+    tag, add another synthetic case shaped like the failure and re-check there first, rather than
+    re-tuning thresholds blind again. `brown`/`beige` are still carved out of the orange hue range
+    by lightness/saturation (common on this gallery's actual content - wood, stone, concrete, rust
+    - where "orange" alone wouldn't be a useful tag), and the rest of the hue wheel still maps to
+    red/orange/yellow/green/cyan/blue/purple/pink, unchanged from the first version. The two call
+    sites are unchanged: `detectDominantColorTag(file)` runs on the local `File` object in the
+    admin upload dock / Publish Queue path (`processUpload()`, in parallel with the network upload
+    itself so it adds no extra wait), while `detectDominantColorTagFromUrl(url)` runs when Review
+    Submissions' "Add" button publishes an image that's already sitting on Cloudinary from the
+    original public submission (no local `File` exists for that path at all - see the Review
+    Submissions note above) by loading a small `w_64` Cloudinary transform into an `<img
+    crossOrigin="anonymous">` and reading it back via canvas; this depends on Cloudinary serving
+    delivery URLs with CORS enabled, which it does by default, but if that were ever not true the
+    canvas read throws (a tainted-canvas security error) and detection just silently returns
+    `null` rather than blocking the Add. Both call sites are try/caught to never fail the publish
+    itself - a failed color detection just means no color tag gets added, same as if nothing had
+    been typed into Keywords.
 - **`netlify/functions/upload.js`** — receives multipart uploads (Busboy), pushes the file to
   Cloudinary, pre-generates 1200px/1920px derived sizes (`eager`) so the frontend's
   `cloudinaryDisplayUrl()` requests don't transform on first view.
@@ -248,6 +322,27 @@ done from a coding session, no Firebase CLI/project access here). Persistence is
 `SESSION` (not Firebase's `LOCAL` default) — closing the tab/browser signs the admin back out
 automatically, at the owner's request; a same-tab refresh still keeps the session, since
 `sessionStorage` (what `SESSION` persistence uses) survives a reload, just not closing the tab.
+
+**Chrome "save password?" false-trigger fix (2026-07-30)** — reported as the browser offering to
+save a password with a *category name* as the username while publishing images, nowhere near the
+login modal. Root cause: `#adminEmailInput`/`#adminPasswordInput` are always present in the DOM
+(just visually hidden via `.modal-backdrop`'s `opacity: 0; visibility: hidden`, not removed), and
+were never wrapped in a `<form>`, so Chrome's save-password heuristic wasn't scoped to just those
+two fields - it could pair the (structurally-present) password field with *any* text input typed
+elsewhere on the page later, e.g. the "Add Folder" name field. Two fixes, both worth keeping if
+this is revisited: (1) the fields are now wrapped in `<form id="adminLoginForm" autocomplete="off">`
+- `#adminLoginBtn` had to get an explicit `type="button"` to stop it becoming an implicit submit
+button once inside a real `<form>` (which would otherwise reload the page), and the form also has
+its own `submit` listener calling `preventDefault()` as a second layer against the browser's
+implicit-submit-on-Enter behavior, on top of the existing per-input keydown handlers; (2) the
+existing readonly-until-focused / cleared-on-modal-open trick (see below) had a gap - a successful
+sign-in cleared the fields' values but never restored `readonly`, so after signing in they sat in
+the DOM empty-but-editable for the rest of the admin's session (however long that was), which is
+exactly the state that let a later, unrelated text input get treated as loosely "part of the same
+form" by Chrome. `attemptAdminSignIn()` now restores `readonly` on success too, closing that
+window. Neither fix is a guaranteed 100% stop to this Chrome behavior (there isn't one - sites far
+bigger than this one still hit it occasionally), so if it recurs, layering on another mitigation is
+more promising than assuming these two didn't work at all.
 
 The client-side button-hiding (`auth.onAuthStateChanged` toggling `editButtons`/`separators`) is
 **cosmetic only** — it exists so a random visitor doesn't see admin controls cluttering the page,

--- a/index.html
+++ b/index.html
@@ -297,12 +297,10 @@
     .folder-list > li.all {
       font-weight: 600;
       font-size: 1.1rem;
-      /* Thin separator from "New This Week" above, matching the .separator
-         <hr> used elsewhere in the sidebar - a border here instead of an
-         actual <hr> since <li> is the only valid direct child of the
-         <ul class="folder-list">. */
-      border-top: 1px solid var(--border-color);
-      padding-top: 0.6rem;
+      /* No top separator (2026-07-30: removed along with moving "New This
+         Week" below "All" instead of above it) - "All" is the first item
+         in the list now, so there's nothing above it left to separate
+         from. */
       margin-bottom: 0.8rem;
       color: var(--text);
     }
@@ -560,6 +558,58 @@
     .size-icon.selected {
       background-color: var(--accent-soft);
       color: var(--accent);
+    }
+
+    /* --------------------------------------------------
+       Floating Color Filter Panel (2026-07-30) - same floating-pill
+       treatment as the size panel above, stacked directly on top of it.
+    -------------------------------------------------- */
+    .floating-color-panel {
+      position: fixed;
+      bottom: 66px;
+      right: 18px;
+      left: auto;
+      background-color: rgba(26,26,30,0.85);
+      border: 1px solid var(--border-color);
+      backdrop-filter: blur(10px);
+      -webkit-backdrop-filter: blur(10px);
+      border-radius: var(--radius-md);
+      z-index: 1000;
+      padding: 6px;
+      max-width: 190px;
+      box-shadow: var(--shadow-md);
+    }
+    .color-dot-container {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 5px;
+      justify-content: flex-end;
+    }
+    .color-dot {
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      cursor: pointer;
+      box-sizing: border-box;
+      transition: box-shadow 0.15s ease, transform 0.15s ease;
+    }
+    .color-dot:hover { transform: scale(1.15); }
+    /* A plain border would be invisible against a same-colored swatch, so
+       "selected" is a ring built from two stacked box-shadows instead -
+       one matching the panel's own background as a gap, then the accent
+       color outside it - which reads clearly against any swatch color. */
+    .color-dot.selected {
+      box-shadow: 0 0 0 2px rgba(26,26,30,0.95), 0 0 0 4px var(--accent);
+    }
+    /* The white and black swatches need their own edge, or each
+       disappears into the panel's own dark background when not
+       selected - white because it's the opposite extreme, black because
+       it's nearly the same dark tone as the panel itself. */
+    .color-dot[data-color="white"] {
+      border: 1px solid rgba(255,255,255,0.35);
+    }
+    .color-dot[data-color="black"] {
+      border: 1px solid rgba(255,255,255,0.2);
     }
 
     /* --------------------------------------------------
@@ -1400,6 +1450,7 @@
   .floating-size-panel { right: 12px; bottom: 12px; }
   .size-icon-container { gap: 4px; }
   .size-icon { width: 30px; height: 30px; font-size: 0.72rem; }
+  .floating-color-panel { right: 12px; bottom: 60px; max-width: 168px; }
 }
 
 /* Extra-narrow phones: shrink the sidebar further and drop the brand text
@@ -1703,6 +1754,28 @@
       <p id="emptyFolderMessage" class="empty-folder-message">Nothing here for now</p>
     </div>
   </div>
+  <!-- FLOATING COLOR FILTER PANEL - filters the gallery to images tagged
+       with the clicked color (see dominant-color auto-tagging); click the
+       selected dot again to clear. Images published before this feature
+       existed have no color tag yet and won't match any dot until
+       re-tagged/re-published. -->
+  <div class="floating-color-panel" id="colorFilterPanel" title="Filter by color">
+    <div class="color-dot-container">
+      <div class="color-dot" data-color="black" style="background-color:#1a1a1a;" title="Black"></div>
+      <div class="color-dot" data-color="white" style="background-color:#f5f5f0;" title="White"></div>
+      <div class="color-dot" data-color="gray" style="background-color:#8e8e93;" title="Gray"></div>
+      <div class="color-dot" data-color="brown" style="background-color:#8b5e34;" title="Brown"></div>
+      <div class="color-dot" data-color="beige" style="background-color:#d9c7a3;" title="Beige"></div>
+      <div class="color-dot" data-color="red" style="background-color:#e5484d;" title="Red"></div>
+      <div class="color-dot" data-color="orange" style="background-color:#f2994a;" title="Orange"></div>
+      <div class="color-dot" data-color="yellow" style="background-color:#f0c419;" title="Yellow"></div>
+      <div class="color-dot" data-color="green" style="background-color:#34a853;" title="Green"></div>
+      <div class="color-dot" data-color="cyan" style="background-color:#17c3b2;" title="Cyan"></div>
+      <div class="color-dot" data-color="blue" style="background-color:#3b82f6;" title="Blue"></div>
+      <div class="color-dot" data-color="purple" style="background-color:#8b5cf6;" title="Purple"></div>
+      <div class="color-dot" data-color="pink" style="background-color:#ec4899;" title="Pink"></div>
+    </div>
+  </div>
   <!-- FLOATING SIZE PANEL -->
  <div class="floating-size-panel">
     <div class="size-icon-container">
@@ -1841,14 +1914,23 @@
   <div class="modal-content">
     <button class="close-modal-btn" id="closeAdminLoginModalBtn">&times;</button>
     <h3>Admin Sign In</h3>
-    <label for="adminEmailInput">Email:</label>
-    <input type="email" id="adminEmailInput" placeholder="you@example.com" autocomplete="off" readonly>
-    <label for="adminPasswordInput">Password:</label>
-    <input type="password" id="adminPasswordInput" placeholder="Password" autocomplete="off" readonly>
-    <div id="adminLoginError" class="modal-hint" style="display:none;"></div>
-    <div style="margin-top:0.8rem;">
-      <button id="adminLoginBtn">Sign In</button>
-    </div>
+    <!-- Wrapped in its own <form> (2026-07-30) so Chrome scopes its
+         save-password heuristic to just these two fields, instead of
+         pairing the (structurally always-present, just visually hidden)
+         password field below with an unrelated text input typed
+         elsewhere on the page later - e.g. the "Add Folder" name field -
+         which is what was causing "save password?" prompts with a
+         category name offered as the username while publishing images. -->
+    <form id="adminLoginForm" autocomplete="off">
+      <label for="adminEmailInput">Email:</label>
+      <input type="email" id="adminEmailInput" placeholder="you@example.com" autocomplete="off" readonly>
+      <label for="adminPasswordInput">Password:</label>
+      <input type="password" id="adminPasswordInput" placeholder="Password" autocomplete="off" readonly>
+      <div id="adminLoginError" class="modal-hint" style="display:none;"></div>
+      <div style="margin-top:0.8rem;">
+        <button id="adminLoginBtn" type="button">Sign In</button>
+      </div>
+    </form>
   </div>
 </div>
   <!-- Delete Controls -->
@@ -1902,6 +1984,16 @@
     // folder path, so it's kept out of `folders`/Firestore and handled as a
     // special case anywhere filtering branches on the folder path shape.
     const NEW_THIS_WEEK_FILTER = "__new_this_week__";
+    // Active color-dot selection (see the floating color filter panel) -
+    // null means no color filter. ANDed on top of whatever folder/search
+    // filtering is currently showing, in both filterImages() and
+    // performSearch() below, via imageMatchesColorFilter().
+    let currentColorFilter = null;
+    function imageMatchesColorFilter(container) {
+      if (!currentColorFilter) return true;
+      const keywords = (container.getAttribute("data-keywords") || "").toLowerCase();
+      return keywords.split(",").map(k => k.trim()).includes(currentColorFilter);
+    }
     // "Week" here isn't a calendar week - it resets on the 1st of every
     // month and then every 7 days after that (1, 8, 15, 22), so the last
     // window of a month absorbs whatever days are left over (7-10 days
@@ -2001,11 +2093,18 @@
 
     // Admin sign-in elements
     const adminLoginModal = document.getElementById("adminLoginModal");
+    const adminLoginForm = document.getElementById("adminLoginForm");
     const closeAdminLoginModalBtn = document.getElementById("closeAdminLoginModalBtn");
     const adminEmailInput = document.getElementById("adminEmailInput");
     const adminPasswordInput = document.getElementById("adminPasswordInput");
     const adminLoginError = document.getElementById("adminLoginError");
     const adminLoginBtn = document.getElementById("adminLoginBtn");
+
+    // Belt-and-suspenders alongside the <form> wrapper itself: the Sign In
+    // button is already `type="button"` so a click can't trigger a native
+    // submit, but pressing Enter in a lone form field still can - stop
+    // that too rather than letting it reload the page.
+    adminLoginForm.addEventListener("submit", (e) => e.preventDefault());
 
     // Review Submissions elements
     const reviewSubmissionsBtn = document.getElementById("reviewSubmissionsBtn");
@@ -2068,6 +2167,15 @@
         await auth.signInWithEmailAndPassword(email, password);
         adminEmailInput.value = "";
         adminPasswordInput.value = "";
+        // Restore `readonly` here too, not just when the modal re-opens -
+        // otherwise these fields sit in the DOM empty-but-editable for the
+        // rest of the admin's session (however long that is), which is
+        // exactly the state that let Chrome's save-password heuristic
+        // pair this password field with an unrelated text input typed
+        // later elsewhere on the page (e.g. a folder name while
+        // publishing images).
+        adminEmailInput.setAttribute("readonly", "readonly");
+        adminPasswordInput.setAttribute("readonly", "readonly");
         adminLoginModal.classList.remove("active");
       } catch (error) {
         // Deliberately vague - doesn't confirm/deny whether the email is a
@@ -2221,11 +2329,8 @@
     // were explicitly tagged "metal".
     const category = (imgContainer.getAttribute("data-category") || "").toLowerCase();
 
-    if (imgName.includes(searchTerm) || keywords.includes(searchTerm) || category.includes(searchTerm)) {
-      imgContainer.classList.remove("hidden");
-    } else {
-      imgContainer.classList.add("hidden");
-    }
+    const matchesSearch = imgName.includes(searchTerm) || keywords.includes(searchTerm) || category.includes(searchTerm);
+    imgContainer.classList.toggle("hidden", !(matchesSearch && imageMatchesColorFilter(imgContainer)));
   });
   scheduleLayout();
 }
@@ -2440,17 +2545,47 @@ aboutModal.addEventListener("click", (e) => {
     }
 
     // --------------------------------------------------------------
-    // Dominant-color detection (2026-07-30) - run automatically on every
-    // publish (admin upload dock and Review Submissions' "Add") so the
-    // resulting image gets a plain-language color tag (e.g. "brown",
-    // "gray") without anyone typing one in. This is a coarse classifier,
-    // not a precise color picker: it buckets the image's most-common
-    // pixel color into one of a handful of everyday color names via HSL
-    // hue/saturation/lightness ranges, which is plenty for search/tagging
-    // purposes and far cheaper than anything ML-based (the AI tagging
-    // stack it might otherwise share space with was deliberately removed
-    // - see the note near processUpload() below - so this stays a small,
-    // dependency-free heuristic on purpose).
+    // Dominant-color detection (2026-07-30, re-worked same day after real
+    // test photos came back badly misclassified - see below) - run
+    // automatically on every publish (admin upload dock and Review
+    // Submissions' "Add") so the resulting image gets a plain-language
+    // color tag (e.g. "brown", "gray") without anyone typing one in.
+    // ------------------------------------------------------------------
+    // The first version bucketed raw RGB values into a histogram (pixels
+    // quantized into nearby-RGB buckets, most-populated bucket wins, name
+    // that bucket's average color) and picked the single most-frequent
+    // bucket by raw pixel count. On real photos this consistently picked
+    // the wrong region: a real subject's surface has enough natural
+    // lighting variation (highlights, shadow, texture) that its pixels
+    // spread across many nearby-but-distinct RGB buckets and split their
+    // own vote, while a flatter, more uniformly-lit area - a blurred gray
+    // floor in the background, a shadow seam between two wall planes, the
+    // dark gaps between leaves in foliage - stays tightly clustered in a
+    // few buckets and can out-vote the actual subject by raw count alone,
+    // even though it visibly occupies less of the frame. Confirmed against
+    // real test photos: a yellow chair (gray blurred floor in one corner)
+    // came back "gray", a reddish-brown weathered wall came back "gray", a
+    // white/gray wall corner (with a shadowed seam) came back "black", and
+    // green foliage (with dark gaps between leaves) came back "black" -
+    // background/shadow winning over the actual subject in every case.
+    //
+    // Fixed by classifying every sampled pixel individually into a color
+    // name first (via nameColorFromRgb(), same as before) and tallying
+    // votes per *name* instead of per fine-grained RGB bucket - this is
+    // far less sensitive to lighting-driven RGB spread, since a lit vs.
+    // shaded patch of the same material usually still names the same hue
+    // even when their raw RGB values are nowhere near each other. On top
+    // of that, low-chroma pixels (shadow, background blur, gaps - the
+    // exact pixels that were winning before) are excluded from the vote
+    // entirely, *unless* almost the whole image is low-chroma, in which
+    // case the image is genuinely neutral (a true black/white/gray
+    // material) and every pixel counts instead so those still tag
+    // correctly. Verified against ~10 synthetic photos built to mimic
+    // these exact failure shapes (a large but visually-secondary neutral
+    // region alongside a smaller, more-varied colorful subject) in Node
+    // before landing this - if a published image still gets a clearly
+    // wrong color tag, that's the first place to add another synthetic
+    // case and re-check, rather than re-tuning thresholds blind.
     // --------------------------------------------------------------
     function rgbToHsl(r, g, b) {
       r /= 255; g /= 255; b /= 255;
@@ -2471,17 +2606,28 @@ aboutModal.addEventListener("click", (e) => {
     }
 
     // Maps an RGB color to one of a small set of everyday color names.
-    // Neutral bands (black/white/gray) are checked first since hue is
-    // meaningless at very low saturation or extreme lightness; "brown"
-    // and "beige" are carved out of the orange hue range by lightness,
-    // since they're common on the reference materials this gallery
-    // actually holds (wood, concrete, stone, rust) and "orange" alone
-    // wouldn't read as a useful tag for them.
+    // Neutral bands (black/white/gray) are checked first via chroma
+    // (max channel - min channel, 0-1), not HSL's own `s` - `s`'s formula
+    // divides by `(2 - max - min)` near white and `(max + min)` near
+    // black, both of which shrink toward 0 at those extremes, so it
+    // amplifies tiny/insignificant RGB differences (sensor noise, JPEG
+    // artifacts) into misleadingly large "saturation" values right where
+    // it matters most for telling white/black apart from a weak tint.
+    // Chroma has no such blowup, so it's what decides "is this actually a
+    // color, or basically neutral" - `s` is still used below for the
+    // brown/beige lightness carve-out, away from those unstable extremes.
+    // "brown" and "beige" are carved out of the orange hue range by
+    // lightness, since they're common on the reference materials this
+    // gallery actually holds (wood, concrete, stone, rust) and "orange"
+    // alone wouldn't read as a useful tag for them.
     function nameColorFromRgb(r, g, b) {
       const [h, s, l] = rgbToHsl(r, g, b);
-      if (l < 0.10) return 'black';
-      if (l > 0.94 && s < 0.15) return 'white';
-      if (s < 0.10) return 'gray';
+      const chroma = (Math.max(r, g, b) - Math.min(r, g, b)) / 255;
+      if (chroma < 0.12) {
+        if (l < 0.12) return 'black';
+        if (l > 0.90) return 'white';
+        return 'gray';
+      }
       if (h >= 15 && h < 50 && l < 0.45) return 'brown';
       if (h >= 15 && h < 60 && l >= 0.45 && l < 0.88 && s < 0.55) return 'beige';
       if (h < 15 || h >= 345) return 'red';
@@ -2495,12 +2641,10 @@ aboutModal.addEventListener("click", (e) => {
       return 'gray';
     }
 
-    // Finds the most common color in a canvas via a coarse histogram
-    // (pixels quantized into 24-wide buckets per channel so near-identical
-    // shades of e.g. "concrete gray" collapse into one bucket instead of
-    // splitting the vote), then names that bucket's average color. Reads
-    // from a small offscreen copy (not the full-resolution canvas) purely
-    // for speed - dominant color doesn't need per-pixel precision.
+    // Classifies every sampled pixel (see the block comment above for why
+    // per-pixel name-voting replaced RGB-bucket histogramming) and returns
+    // the most-voted name. Reads from a small offscreen copy of the
+    // canvas, not the full-resolution original, purely for speed.
     function dominantColorNameFromCanvas(canvas) {
       const SAMPLE = 64;
       const sampleCanvas = document.createElement('canvas');
@@ -2510,25 +2654,47 @@ aboutModal.addEventListener("click", (e) => {
       ctx.drawImage(canvas, 0, 0, SAMPLE, SAMPLE);
       const { data } = ctx.getImageData(0, 0, SAMPLE, SAMPLE);
 
-      const buckets = new Map();
+      // Below this, a pixel reads as "basically neutral" (shadow,
+      // background blur, gaps) and is excluded from the vote unless
+      // there's nothing else to work with - see the fallback below.
+      const CHROMA_THRESHOLD = 0.15;
+
+      const tallyInto = (votes, r, g, b) => {
+        const name = nameColorFromRgb(r, g, b);
+        votes.set(name, (votes.get(name) || 0) + 1);
+      };
+
+      let totalCount = 0;
+      let colorfulCount = 0;
+      const colorfulVotes = new Map();
       for (let i = 0; i < data.length; i += 4) {
         if (data[i + 3] < 128) continue; // skip transparent pixels
+        totalCount++;
         const r = data[i], g = data[i + 1], b = data[i + 2];
-        const key = `${r >> 3}_${g >> 3}_${b >> 3}`; // ~24-wide buckets (256/32)
-        let entry = buckets.get(key);
-        if (!entry) { entry = { count: 0, r: 0, g: 0, b: 0 }; buckets.set(key, entry); }
-        entry.count++; entry.r += r; entry.g += g; entry.b += b;
+        const chroma = (Math.max(r, g, b) - Math.min(r, g, b)) / 255;
+        if (chroma < CHROMA_THRESHOLD) continue;
+        colorfulCount++;
+        tallyInto(colorfulVotes, r, g, b);
+      }
+      if (totalCount === 0) return null;
+
+      // Almost nothing in the image cleared the colorfulness bar - that
+      // means the image itself is genuinely neutral (a true black/white/
+      // gray material), not that its real color got filtered out, so
+      // fall back to voting on every pixel instead of just the (near-
+      // nonexistent) colorful ones.
+      let votes = colorfulVotes;
+      if (colorfulCount < totalCount * 0.05) {
+        votes = new Map();
+        for (let i = 0; i < data.length; i += 4) {
+          if (data[i + 3] < 128) continue;
+          tallyInto(votes, data[i], data[i + 1], data[i + 2]);
+        }
       }
 
-      let best = null;
-      buckets.forEach(entry => { if (!best || entry.count > best.count) best = entry; });
-      if (!best) return null;
-
-      return nameColorFromRgb(
-        Math.round(best.r / best.count),
-        Math.round(best.g / best.count),
-        Math.round(best.b / best.count)
-      );
+      let bestName = null, bestCount = 0;
+      votes.forEach((count, name) => { if (count > bestCount) { bestCount = count; bestName = name; } });
+      return bestName;
     }
 
     // For a local File about to be uploaded (admin upload dock / Publish
@@ -2949,27 +3115,6 @@ downloadLink.addEventListener("click", function(e) {
       folderSelect.innerHTML = "";
       parentFolderSelect.innerHTML = "<option value=''>No Parent</option>";
 
-      const newThisWeekItem = document.createElement("li");
-      newThisWeekItem.classList.add("new-this-week");
-      newThisWeekItem.setAttribute("data-filter", NEW_THIS_WEEK_FILTER);
-      const newThisWeekLabel = document.createElement("span");
-      newThisWeekLabel.classList.add("folder-label");
-      const newThisWeekNameSpan = document.createElement("span");
-      newThisWeekNameSpan.classList.add("folder-name");
-      newThisWeekNameSpan.textContent = "New This Week";
-      const newThisWeekCountSpan = document.createElement("span");
-      newThisWeekCountSpan.classList.add("folder-count");
-      newThisWeekLabel.appendChild(newThisWeekCountSpan);
-      newThisWeekLabel.appendChild(newThisWeekNameSpan);
-      newThisWeekItem.appendChild(newThisWeekLabel);
-      newThisWeekItem.addEventListener("click", () => {
-        highlightSelected(newThisWeekItem);
-        hideAllSubfolders();
-        currentFolderFilter = NEW_THIS_WEEK_FILTER;
-        filterImages(NEW_THIS_WEEK_FILTER);
-      });
-      folderList.appendChild(newThisWeekItem);
-
       const allItem = document.createElement("li");
       allItem.classList.add("all");
       allItem.setAttribute("data-filter", "all");
@@ -2990,6 +3135,29 @@ downloadLink.addEventListener("click", function(e) {
         filterImages("all");
       });
       folderList.appendChild(allItem);
+
+      // Below "All" (2026-07-30, moved from above it) - a normal-looking
+      // category like any other, just first among the actual folders.
+      const newThisWeekItem = document.createElement("li");
+      newThisWeekItem.classList.add("new-this-week");
+      newThisWeekItem.setAttribute("data-filter", NEW_THIS_WEEK_FILTER);
+      const newThisWeekLabel = document.createElement("span");
+      newThisWeekLabel.classList.add("folder-label");
+      const newThisWeekNameSpan = document.createElement("span");
+      newThisWeekNameSpan.classList.add("folder-name");
+      newThisWeekNameSpan.textContent = "New This Week";
+      const newThisWeekCountSpan = document.createElement("span");
+      newThisWeekCountSpan.classList.add("folder-count");
+      newThisWeekLabel.appendChild(newThisWeekCountSpan);
+      newThisWeekLabel.appendChild(newThisWeekNameSpan);
+      newThisWeekItem.appendChild(newThisWeekLabel);
+      newThisWeekItem.addEventListener("click", () => {
+        highlightSelected(newThisWeekItem);
+        hideAllSubfolders();
+        currentFolderFilter = NEW_THIS_WEEK_FILTER;
+        filterImages(NEW_THIS_WEEK_FILTER);
+      });
+      folderList.appendChild(newThisWeekItem);
 
       const structure = buildFolderStructure();
       const parents = Object.keys(structure).sort();
@@ -3156,35 +3324,26 @@ downloadLink.addEventListener("click", function(e) {
   const allImages = document.querySelectorAll(".image-container");
   allImages.forEach(container => {
     const category = container.getAttribute("data-category");
+    let shouldShow;
 
     if (filterValue === "all") {
       // Show all images for "All" folder
-      container.classList.remove("hidden");
+      shouldShow = true;
     }
     else if (filterValue === NEW_THIS_WEEK_FILTER) {
       const addTime = parseInt(container.getAttribute("data-add-time")) || 0;
-      if (addTime >= windowStart) {
-        container.classList.remove("hidden");
-      } else {
-        container.classList.add("hidden");
-      }
+      shouldShow = addTime >= windowStart;
     }
     else if (!filterValue.includes("/")) {
       // For parent folders, show images from this folder AND any subfolders
-      if (category === filterValue || category.startsWith(filterValue + "/")) {
-        container.classList.remove("hidden");
-      } else {
-        container.classList.add("hidden");
-      }
+      shouldShow = category === filterValue || category.startsWith(filterValue + "/");
     }
     else {
       // For subfolders, only show exact matches
-      if (category === filterValue) {
-        container.classList.remove("hidden");
-      } else {
-        container.classList.add("hidden");
-      }
+      shouldShow = category === filterValue;
     }
+
+    container.classList.toggle("hidden", !(shouldShow && imageMatchesColorFilter(container)));
   });
   scheduleLayout();
 }
@@ -4332,11 +4491,22 @@ function closeEnlargeModal() {
       resetImageModal();
     });
 
+    // Bumped into every uploadBatchId below (2026-07-30) - Date.now() alone
+    // collides when Publish All fires startUploadBatch() once per queued
+    // batch in a single synchronous forEach: two batches landing in the
+    // same millisecond got identical uploadItemId values, so their dock
+    // rows had duplicate DOM ids. getElementById() always resolves to the
+    // *first* match, so the second batch's progress updates silently
+    // landed on the first batch's row instead of its own - leaving the
+    // second batch's actual row stuck at its initial "0%" template state
+    // forever, even though the upload itself was proceeding normally.
+    let uploadBatchCounter = 0;
+
     // Creates a dock row and kicks off processUpload() for each file in a
     // batch. Shared by the immediate Add button and Publish All so both
     // paths behave identically.
     function startUploadBatch(files, folderValue, keywords) {
-      const uploadBatchId = Date.now();
+      const uploadBatchId = `${Date.now()}-${uploadBatchCounter++}`;
 
       const uploadDock = document.getElementById("uploadDock");
       if (!uploadDock) {
@@ -4547,6 +4717,27 @@ async function completeUpload(imageUrl, folderValue, combinedKeywords, fileName,
         const newSize = icon.getAttribute("data-size");
         document.documentElement.style.setProperty("--row-height", newSize + "px");
         layoutGallery();
+      });
+    });
+
+    // Color filter dots - single-select, click the selected dot again to
+    // clear. Re-runs performSearch() (not filterImages() directly) so
+    // whichever base filter is currently active - a folder selection or
+    // typed search text - gets re-applied with the color filter ANDed on
+    // top of it, via imageMatchesColorFilter() inside both functions.
+    const colorDots = document.querySelectorAll(".color-dot");
+    colorDots.forEach(dot => {
+      dot.addEventListener("click", () => {
+        const color = dot.getAttribute("data-color");
+        if (currentColorFilter === color) {
+          currentColorFilter = null;
+          dot.classList.remove("selected");
+        } else {
+          colorDots.forEach(d => d.classList.remove("selected"));
+          currentColorFilter = color;
+          dot.classList.add("selected");
+        }
+        performSearch();
       });
     });
 


### PR DESCRIPTION
## Summary

Follow-up to #30 (merged), addressing feedback from real use of that change:

- **Chrome "save password?" false trigger fixed.** Reported as an unrelated category name being offered as the username while publishing images. Root cause: the admin login's email/password fields are always in the DOM (just visually hidden via the modal backdrop's `opacity`/`visibility`, not removed), with no `<form>` boundary scoping them — Chrome's save-password heuristic could pair the password field with *any* text input typed elsewhere later (e.g. the "Add Folder" name field). Fixed by wrapping the fields in their own `<form>` (with the Sign In button set to `type="button"` and a `submit` listener as a safety net against implicit Enter-submission reloading the page), and by restoring `readonly` after a successful sign-in — previously it was only reset when the modal re-opened, so a signed-in admin's session left the fields empty-and-editable in the DOM the whole time.
- **Sidebar order fixed.** "New This Week" now renders below "All" as a plain category instead of above it; "All"'s top border/separator (which existed specifically to separate it from "New This Week" sitting above) is removed since "All" is first now.
- **Dominant-color detection accuracy reworked.** The previous histogram-bucket approach consistently lost to background/shadow regions on real photos — confirmed with 4 real test photos: a yellow chair (blurred gray floor in one corner) came back "gray", a reddish-brown wall came back "gray", a white/gray wall corner with a shadow seam came back "black", and green foliage (dark gaps between leaves) came back "black". Replaced with per-pixel color-name voting, which is far less sensitive to lighting-driven RGB spread (a lit vs. shaded patch of the same material still names the same hue even when their raw RGB values are far apart), and excludes low-chroma/shadow pixels from the vote unless the whole image is genuinely neutral. Also fixed a numerical-instability bug in the neutral (black/white/gray) gate: HSL's saturation formula blows up near the lightness extremes, so tiny sensor-noise/JPEG-artifact differences near pure white or black were misread as strong color saturation. Verified against ~10 synthetic pixel-population test cases built to mimic the real failure shapes, directly in Node, before landing this.
- **Fixed a real upload-progress bug found via testing:** some images in a multi-batch publish (Publish All, with several categories queued) stayed stuck at "0%" in the upload dock forever, even though the upload itself was completing normally. `startUploadBatch()` derived each dock row's DOM id from `Date.now()`, and Publish All fires it once per queued batch in a tight synchronous loop — batches landing in the same millisecond got colliding DOM ids, so `document.getElementById()` (which always resolves to the *first* match) silently routed later batches' progress updates to an earlier batch's row instead of their own. Fixed with a monotonically-incrementing counter alongside the timestamp, guaranteeing unique ids regardless of timing.
- **New: floating color filter panel**, styled to match the existing size selector (stacked directly above it). One dot per color the auto-tagger can produce (black/white/gray/brown/beige/red/orange/yellow/green/cyan/blue/purple/pink); clicking a dot narrows the gallery to images tagged with that color, ANDed with whatever folder/search filter is already active (click the selected dot again to clear). A quality filter (SD/HD/2K/4K) was also requested but deferred — there's no image-resolution data stored anywhere today, and per your answer, backfilling the ~191 existing images just to support it wasn't worth doing right now.

See `CLAUDE.md` for detailed notes on all of the above, including why each bug happened and what to check if something similar recurs.

## Test plan

- [x] `npm test` (existing Jest suite, unaffected — passes)
- [x] Verified `index.html`'s inline script still parses (`new Function(...)` on the extracted script block)
- [x] Headless-browser (Playwright + Chromium) smoke tests with a stubbed Firebase:
  - Confirmed sidebar order ("All" first, "New This Week" second, no separator) and correct DOM structure
  - Confirmed the admin login form: pressing Enter no longer reloads the page, sign-in still fires correctly, fields are inside `<form id="adminLoginForm">`
  - Confirmed the color filter panel: clicking a dot narrows visible images correctly, combines (AND) correctly with both folder selection and search text, toggles off correctly, and single-selects correctly (selecting a new dot deselects the previous one) — verified against synthetic image containers with real `data-keywords`/`data-category` attributes
- [x] Unit-tested the reworked color classifier (`nameColorFromRgb`, `dominantColorNameFromCanvas`'s voting logic) against ~10 synthetic pixel-population cases built to reproduce the four real reported failures, plus pure black/white/gray/red/blue sanity cases and a "small colorful accent in a mostly-gray image" case — all passing, directly against the code extracted from `index.html`
- [ ] Not tested: the live upload → Cloudinary → Firestore path end-to-end, or the color detection against the actual real photos from the report (no live Cloudinary/Firebase network access in this sandboxed session)


---
_Generated by [Claude Code](https://claude.ai/code/session_01P82KjUNAbapvhwj6c27NhH)_