### PR TITLE
Fix upload stability, color mistags, image flash, and add safety guards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -420,9 +420,133 @@ with admin-only upload/tagging/organizing tools. Deployed on Netlify.
     can open the browser console during a Re-tag Colors run (or a fresh upload) to paste the
     `[color detect] ...` line for that image, and treat that as real ground truth instead of
     guessing at another pipeline-level theory blind, the same lesson as every round before this one.
+    **Fourth pass, 2026-07-31, same day** — reported broken again (leaves, fire hydrants still
+    gray), still with no real `[color detect]` console line to go on. Rather than tune blind again,
+    this pass built an actual reproduction: a Playwright + real Chromium `<canvas>` harness (not
+    plain Node pixel arrays — those never exercise `dominantColorNameFromCanvas()`'s own
+    `ctx.drawImage()` downsample step at all, which is exactly why every prior "verified in Node"
+    claim couldn't have caught a bug living in that step) that draws synthetic photos shaped like
+    the real failures and runs the *actual* function against them. This reproduced it: a saturated
+    subject covering ~15% of the frame against a much larger (~85%) background that's only mildly
+    desaturated (chroma ~0.05–0.15 — overcast light, gravel, muted grass; not the near-zero-chroma
+    "obviously neutral" case FLOOR/CAP were tuned around) reliably came back "gray" at the
+    then-current FLOOR/CAP of 0.05/0.25, regardless of sample resolution. Cause: a background that
+    dull never reaches the 0.25 cap, so it accumulates its full (if modest) per-pixel chroma across
+    a much larger area than the subject can, while the subject's own weight is held down at 0.25
+    regardless of how saturated it actually is — raw area wins. Fixed by raising CAP to 0.50 and
+    lowering FLOOR to 0.03 (`dominantColorNameFromCanvas()`), which fixed the reproduction while
+    still passing every previously-documented regression shape re-run against the same harness: a
+    large moderately-colored subject (a wood pole, chroma ~0.3) still beats a small vivid sliver (a
+    sky patch, chroma ~0.6, ~8% of frame) — the original 2026-07-31 "small vivid sliver" regression
+    this cap exists for — a large dull subject still beats both a small vivid sliver (~3% of frame)
+    and an even smaller max-saturation one (~2%), and a fully neutral material still comes back
+    neutral. **If another image is still wrong after this, extend that harness with a case shaped
+    like the new failure first** (or get a real `[color detect]` console line, if someone can) —
+    don't re-tune these two numbers blind again; that's the mistake every prior pass made.
+  - **Stability: delete/move/edit-tags/re-tag now target a Firestore doc id, not a url lookup
+    (2026-07-31)** — prompted by "make sure images won't disappear randomly." `findImageIdByUrl()`
+    (`where('url','==',url).limit(1)`) is ambiguous whenever two `images` docs share the same url,
+    which the **Find Duplicates** admin tool exists specifically because it really happens (e.g.
+    clicking Review Submissions' "Add" twice on the same submission). When that happens, `.limit(1)`
+    silently resolves to *whichever* doc Firestore returns first — delete/move/edit-tags/re-tag-colors
+    would all appear to work (the clicked container disappears from the DOM immediately) while the
+    Firestore doc actually touched could belong to a *different* image, which then just doesn't
+    reappear on the next reload, no error anywhere. `addImageToGallery()` now takes an optional
+    `docId` 6th argument and stashes it as `container.dataset.docId`; `saveImageToFirebase()` returns
+    the new doc's id so every creation path (`loadImagesFromFirebase()`, `completeUpload()`, Review
+    Submissions' "Add") can pass it through. `getImageDocId(container)` is the new single point every
+    mutating call site (delete, move, edit tags, re-tag colors) goes through — uses
+    `dataset.docId` when present, only falls back to the old ambiguous `findImageIdByUrl()` for any
+    container that somehow never got one. Doesn't fix *why* duplicate urls occur in the first place
+    (Find Duplicates is still the only cleanup tool for existing ones) — this just stops that
+    situation from silently corrupting an unrelated image's data when it does.
+  - **`netlify/functions/upload.js`'s `public_id` collision (2026-07-31)** — see that file's own
+    entry below; same stability audit.
+  - **Thumbnails get `loading="lazy"`/`decoding="async"` (2026-07-31)** — prompted by "lags on
+    slower laptops when scrolling, and some images load slowly." Every gallery thumbnail (plus
+    Review Submissions' thumbnails) used to fire its network fetch immediately on page load
+    regardless of scroll position — with ~200 images that's ~200 concurrent requests and decodes
+    competing for bandwidth and main-thread time on every visit, even for images the visitor never
+    scrolls to. Native lazy-loading defers the fetch until near-viewport instead. Interacts with the
+    justified-layout algorithm in one way worth knowing: an image's `data-aspect` only becomes real
+    (vs. the 1.5 fallback) once its `load` event fires, which for a lazy image is only once it's
+    about to scroll into view — `layoutGallery()` re-packs from the changed image's row *onward*
+    only (rows before it in DOM order are unaffected, since row-packing is sequential and
+    deterministic per prior images' own aspect data), so this shows up as a minor row reflow right at
+    the loading edge as the visitor scrolls, never a shift of content already above the fold. This is
+    normal/expected for any lazy-loaded justified or masonry gallery, not a bug to chase.
+  - **`.image-container`'s "flashes a huge image, then snaps to normal size" bug (2026-07-31)** —
+    root cause: `.image-container` had no width/height of its own at rest (only `flex: 0 0 auto`),
+    and its `<img>` is `width:100%; height:100%` — CSS resolves that against the *image's own*
+    intrinsic pixel size when the container itself is otherwise unconstrained, so a container
+    rendered at its photo's full native resolution (thousands of px) until `layoutGallery()` set an
+    explicit inline pixel width/height (throttled ~60ms, and again per-image on that image's own
+    `load` event). Fixed by giving `.image-container` a default `width: calc(var(--row-height) *
+    1.5); height: var(--row-height)` — matches the same 1.5 fallback aspect `addImageToGallery()`
+    already seeds `data-aspect` with, so the default and the JS-computed fallback agree. Verified via
+    a headless Chromium load with a stubbed Firestore (three fake images) — containers stayed at a
+    bounded, sane size (matching `--row-height`) both immediately after the containers were created
+    and after `layoutGallery()` settled; the real photo-swap-to-huge-then-shrink motion itself isn't
+    reproducible in this sandbox (no live Cloudinary/real photo bytes to load), so this is verified
+    by CSS box-model reasoning plus bounded-size confirmation, not a literal before/after screenshot
+    of the flash.
+  - **Default gallery size changed S → M (2026-07-31)** — `--row-height` 180px → 240px, and the
+    `.size-icon.selected` class moved from the S icon to the M icon in the floating size panel's
+    markup. Both need to change together (or a page load and the panel's own highlighted icon
+    disagree about what's actually selected).
+  - **Folder deletion hardened (2026-07-31)** — `deleteFolderBtn`'s handler already only ever
+    reassigns affected images' `folder` field to `'all'` (a Firestore batch `.update()`) and never
+    touches the `images` collection's docs themselves — deleting a folder was never actually deleting
+    photos, just the folder doc(s). What was missing: (1) the confirm dialog didn't say so, which
+    read as ambiguous and was reported as a point of confusion — it now spells out "Its images are
+    NOT deleted - they'll stay in the gallery, moved to 'All'" up front, before the admin confirms;
+    (2) `"All"` was already blocked from being deleted/renamed, but `NEW_THIS_WEEK_FILTER` (the
+    virtual "New This Week" category — never a real folder doc, see its own definition) was not —
+    selecting it and clicking Delete Folder or Rename Folder fell through to the real flow (a
+    harmless no-op against Firestore, since nothing actually has that literal folder value, but
+    still surfaced a real, confusing confirm/rename dialog). Both buttons now explicitly block both
+    virtual categories with one alert.
+  - **Bulk-delete warning for 20+ images (2026-07-31, `BULK_DELETE_WARNING_THRESHOLD`)** — selecting
+    20 or more images in Delete Images mode and clicking Delete Selected now shows an extra,
+    more alarming `confirm()` *before* the normal one ("You're about to delete N images... cannot be
+    undone. Are you SURE?") — meant to catch an accidental mass-delete (a fat-fingered
+    select-everything click, or forgetting Delete Images mode was still on from earlier) since two
+    separate prompts are harder to blow through on autopilot than one dialog with more text in it.
+    Dismissing either dialog aborts with nothing deleted; accepting both proceeds exactly as before.
+  - **Review Submissions button restyled + moved to the top of the admin controls (2026-07-31)** —
+    moved out of `.admin-bottom-buttons` into its own new first section of `.sidebar-footer` (above
+    even Add Folder/Add Image), and given its own `.review-btn` class (green, via a new
+    `--success-soft` token alongside the existing `--success`) instead of the unstyled default admin
+    button look. It's flagging incoming work waiting on the admin (pending public submissions), not
+    a select-then-act gallery-editing tool like Move/Delete/Edit Tags next to it, which is why it's
+    both visually distinct and first, not sorted in wherever alphabetically/historically.
+  - **Upload dock: wider progress bar + ETA (2026-07-31)** — `.upload-dock-global-progress` lost its
+    480px `max-width` cap (now just `flex: 1; min-width: 0`) so it actually fills the space next to
+    the title/stats instead of stopping well short of the dock's own already-wide (`min(1100px, ...)`)
+    container. Added an estimated-time-remaining label (`#uploadDockEta`,
+    `.upload-dock-stats`/`.upload-dock-eta`) next to it — `updateGlobalUploadProgress()` now tracks
+    `uploadBatchStartTime` (reset to `null` whenever the dock empties out, so a later unrelated batch
+    gets its own fresh estimate) and projects total time from elapsed-time ÷ overall-percent-so-far,
+    not just done/total file count, so it updates smoothly mid-file rather than only jumping when a
+    whole file finishes. Held back behind "Estimating…" for the first ~1.5s / first 3% of progress —
+    too little signal that early makes for a wildly unstable projection. The existing "done/total"
+    count (`#uploadDockCount`) was already there from the 2026-07-31 dock rebuild above and didn't
+    need to change.
 - **`netlify/functions/upload.js`** — receives multipart uploads (Busboy), pushes the file to
   Cloudinary, pre-generates 1200px/1920px derived sizes (`eager`) so the frontend's
-  `cloudinaryDisplayUrl()` requests don't transform on first view.
+  `cloudinaryDisplayUrl()` requests don't transform on first view. Cloudinary's `public_id` used to
+  be derived from `Date.now()-filename` alone (2026-07-31: now `Date.now()-<random suffix>-filename`)
+  — a stability audit (prompted by "make sure images won't disappear randomly") flagged that two
+  uploads sharing the same filename landing in the same millisecond would collide on `public_id`,
+  and Cloudinary's default upload behavior *overwrites* an existing asset at a colliding
+  `public_id` rather than erroring — silently replacing a previously-uploaded image's actual content
+  with the new one. Each request here is its own Netlify function invocation (a separate process),
+  so there's no shared in-memory counter to reach for the way the frontend's `uploadBatchCounter`
+  fix (see Publish Queue below) closed the equivalent gap client-side — a random suffix is what
+  closes it here regardless of how many invocations are concurrently in flight. Untested against
+  live Cloudinary (same sandbox limitation as everything else touching it in this repo); the
+  `tests/upload.test.js` assertions (`public_id` contains the filename, isn't just the filename)
+  still hold.
 - **Firestore** — three collections: `folders` (name, parent), `images` (url, folder, keywords,
   filename, timestamp), and `submissions` (link, imageUrls, note, timestamp — see "Submit" above).
   Access is controlled by real Firestore security rules now — see "Admin access" below and

--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
       --danger: #ff5a52;
       --danger-soft: rgba(255,90,82,0.16);
       --success: #4cd964;
+      --success-soft: rgba(76,217,100,0.16);
       --move-accent: #4d9bf5;
       --move-soft: rgba(77,155,245,0.16);
       --tag-accent: #a374e0;
@@ -36,7 +37,7 @@
       --radius-lg: 18px;
       --shadow-md: 0 10px 28px rgba(0,0,0,0.4);
       --gallery-gap: 6px;
-      --row-height: 180px; /* default gallery size = S */
+      --row-height: 240px; /* default gallery size = M */
       --sidebar-width: 270px;
 
       /* legacy aliases kept for any untouched rules */
@@ -414,6 +415,17 @@
       color: var(--move-accent);
       border-color: transparent;
     }
+    /* Review Submissions: green, and bolder than the other admin buttons -
+       it's the one that flags incoming work waiting on the admin (pending
+       public submissions), not a select-then-act gallery tool, so it's
+       kept visually distinct and moved to the top of the admin controls
+       instead of sitting alphabetically/arbitrarily among them. */
+    .sidebar-footer button.review-btn {
+      background-color: var(--success-soft);
+      color: var(--success);
+      border-color: transparent;
+      font-weight: 600;
+    }
     /* Thin separator */
     .separator {
       border: 0;
@@ -468,6 +480,19 @@
   border-radius: var(--radius-xs);
   background-color: var(--bg-sunken);
   cursor: pointer;
+  /* Fallback size, matching the 1.5 fallback aspect ratio addImageToGallery()
+     seeds data-aspect with. layoutGallery() overwrites this with an exact
+     inline width/height once it runs (throttled ~60ms), but before that -
+     on first paint, and again for every image whose "load" event hasn't
+     fired yet - a container has no other size of its own: its <img> is
+     width:100%/height:100%, which resolves against the *image's own*
+     intrinsic pixel size when the container itself is unconstrained. That
+     was the site's "flashes a huge image, then snaps to normal size" bug -
+     a multi-thousand-pixel phone photo rendering at its native size for a
+     frame or two on load. Don't remove this without another way to bound
+     the container's size before JS lays it out. */
+  width: calc(var(--row-height) * 1.5);
+  height: var(--row-height);
 }
     .image-container img {
       display: block;
@@ -1349,8 +1374,11 @@
 }
 
 .upload-dock-global-progress {
+  /* No max-width cap (was 480px) - the bar now fills essentially all the
+     space the title/stats/action buttons don't need, instead of stopping
+     well short of the dock's own (already wide) 1100px max-width. */
   flex: 1;
-  max-width: 480px;
+  min-width: 0;
   height: 8px;
   background-color: rgba(255,255,255,0.1);
   border-radius: 4px;
@@ -1362,6 +1390,22 @@
   background-color: var(--move-accent);
   width: 0%;
   transition: width 0.3s ease;
+}
+
+.upload-dock-stats {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  flex-shrink: 0;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.upload-dock-eta {
+  min-width: 84px;
+  text-align: right;
 }
 
 .upload-dock-header-actions {
@@ -1784,6 +1828,14 @@
       </ul>
       <!-- SIDEBAR FOOTER: Admin Editing Controls -->
       <div class="sidebar-footer">
+        <!-- Review Submissions sits at the top, ahead of everything else,
+             and is colored distinctly from the other admin tools - it's
+             flagging incoming work (pending public submissions) rather
+             than being a gallery-editing tool like the ones below it. -->
+        <div class="admin-review-section">
+          <button id="reviewSubmissionsBtn" class="review-btn">Review Submissions</button>
+        </div>
+        <hr class="separator">
         <div class="admin-top-buttons">
           <button id="newFolderAdminBtn">Add Folder</button>
           <button id="addImageAdminBtn">Add Image</button>
@@ -1796,7 +1848,6 @@
           <button id="deleteImageBtn" class="delete-btn">Delete Images</button>
           <button id="deleteFolderBtn" class="delete-btn">Delete Folder</button>
           <button id="findDuplicatesBtn">Find Duplicates</button>
-          <button id="reviewSubmissionsBtn">Review Submissions</button>
           <button id="retagColorsBtn">Re-tag Colors</button>
         </div>
         <hr class="separator">
@@ -1843,8 +1894,8 @@
     <div class="floating-size-panel">
       <div class="size-icon-container">
         <div class="size-icon" data-size="120"><span>XS</span></div>
-        <div class="size-icon selected" data-size="180"><span>S</span></div>
-        <div class="size-icon" data-size="240"><span>M</span></div>
+        <div class="size-icon" data-size="180"><span>S</span></div>
+        <div class="size-icon selected" data-size="240"><span>M</span></div>
         <div class="size-icon" data-size="320"><span>L</span></div>
         <div class="size-icon" data-size="420"><span>XL</span></div>
       </div>
@@ -2813,8 +2864,41 @@ aboutModal.addEventListener("click", (e) => {
       // could still outvote a much larger but only moderately-saturated
       // subject. Capping means a moderately-colored subject only has to
       // out-NUMBER the vivid sliver, not out-saturate it too.
-      const CHROMA_FLOOR = 0.05;
-      const CHROMA_CAP = 0.25;
+      //
+      // 2026-07-31, third pass: FLOOR/CAP were 0.05/0.25. Real re-tagged
+      // photos (a fire hydrant, foliage) kept coming back "gray" even
+      // after the w_200/q_90 compression bump above, still with no
+      // console access to confirm why against the *actual* photos - but
+      // this time it was reproduced for real, not guessed at: a synthetic
+      // Playwright/Canvas harness (outside this sandbox's normal test
+      // setup, since the bug is in dominantColorNameFromCanvas's own
+      // canvas sampling, which plain Node pixel-array tests never
+      // exercised at all - see the note above this function) built a
+      // photo shaped like the reports - a saturated red subject covering
+      // ~15% of the frame against a much larger (~85%) *only mildly*
+      // desaturated background (chroma ~0.05-0.15 - overcast lighting,
+      // gravel, muted grass, not the near-zero-chroma "obviously neutral"
+      // case the floor/cap were tuned around) - and it reliably came back
+      // "gray" at 0.05/0.25, on both floor values tried and regardless of
+      // sample resolution. The reason: a background that dull is nowhere
+      // near the 0.25 cap, so it never gets capped down - it just
+      // accumulates its full (if modest) per-pixel chroma across a much
+      // larger area than the subject can, and the subject's own weight is
+      // held down at 0.25 regardless of how saturated it actually is.
+      // Raising CAP to 0.50 and lowering FLOOR to 0.03 fixes that (the
+      // subject's ceiling is now high enough to actually out-vote a large
+      // dull area) while still passing every previously-documented
+      // regression case re-run against the same harness: a large
+      // moderately-colored subject (a wood pole, chroma ~0.3) still beats
+      // a small vivid sliver (a sky patch, chroma ~0.6, ~8% of frame), a
+      // large dull subject still beats both a small vivid sliver (~3%)
+      // and an even smaller max-saturation one (~2%), and a fully neutral
+      // material still comes back neutral. If another image is still
+      // wrong after this, extend that harness with a case shaped like the
+      // new failure (or get a real [color detect] console line, if
+      // someone can) rather than re-tuning these two numbers blind again.
+      const CHROMA_FLOOR = 0.03;
+      const CHROMA_CAP = 0.50;
 
       const votes = new Map();
       for (let i = 0; i < data.length; i += 4) {
@@ -3117,7 +3201,7 @@ aboutModal.addEventListener("click", (e) => {
 
     async function saveImageToFirebase(url, folder, keywords, filename) {
       try {
-        await db.collection('images').add({
+        const docRef = await db.collection('images').add({
           url: url,
           folder: folder,
           keywords: keywords || '',
@@ -3126,8 +3210,10 @@ aboutModal.addEventListener("click", (e) => {
           addTime: Date.now()
         });
         console.log('Image saved to Firestore:', url);
+        return docRef.id;
       } catch (error) {
         console.error('Error saving image:', error);
+        return null;
       }
     }
 
@@ -3138,11 +3224,12 @@ aboutModal.addEventListener("click", (e) => {
         imagesSnapshot.forEach(doc => {
           const imageData = doc.data();
           addImageToGallery(
-            imageData.url, 
-            imageData.folder || 'all', 
+            imageData.url,
+            imageData.folder || 'all',
             imageData.keywords || '',
             imageData.filename || 'image',
-            imageData.addTime || Date.now()
+            imageData.addTime || Date.now(),
+            doc.id
           );
         });
         console.log('Images loaded from Firestore');
@@ -3151,6 +3238,19 @@ aboutModal.addEventListener("click", (e) => {
       }
     }
 
+    // Kept as a fallback for any container that somehow never got a
+    // data-doc-id (see addImageToGallery) - findByUrl() is ambiguous
+    // whenever two images share the same Cloudinary url (Find Duplicates
+    // exists because that really happens - e.g. Review Submissions' "Add"
+    // running twice on the same submission), silently resolving to
+    // whichever doc Firestore's .limit(1) happens to return first. That
+    // mismatch doesn't fail loudly: delete/move/tag-edit would appear to
+    // work (the clicked container disappears from the DOM immediately)
+    // while the Firestore doc actually touched belongs to a *different*
+    // image, which then vanishes from the gallery on the next reload with
+    // no error anywhere - "images disappearing randomly". getImageDocId()
+    // below is the real fix (act on the exact doc id a container was
+    // loaded/created with); this stays only as a last resort.
     async function findImageIdByUrl(url) {
       try {
         const querySnapshot = await db.collection('images').where('url', '==', url).limit(1).get();
@@ -3162,14 +3262,25 @@ aboutModal.addEventListener("click", (e) => {
       }
     }
 
+    // The Firestore doc id an image-container actually corresponds to.
+    // Every call site that mutates/deletes an image's doc (delete, move,
+    // edit tags, re-tag colors) should use this instead of re-deriving the
+    // id from the url each time - see findImageIdByUrl()'s comment above
+    // for why a url-based lookup can silently target the wrong document.
+    async function getImageDocId(container) {
+      if (container.dataset.docId) return container.dataset.docId;
+      return findImageIdByUrl(container.dataset.url);
+    }
+
     /********************************************************
      * UI Functions
      ********************************************************/
-    function addImageToGallery(url, folder, keywords, filename, addTime) {
+    function addImageToGallery(url, folder, keywords, filename, addTime, docId) {
       const container = document.createElement('div');
       container.classList.add('image-container');
       container.setAttribute('data-category', folder);
       container.setAttribute('data-keywords', keywords);
+      if (docId) container.dataset.docId = docId;
       container.setAttribute('data-add-time', addTime);
       // The <img> tag's src is rewritten to a resized Cloudinary display URL
       // (see cloudinaryDisplayUrl() below), which no longer matches the
@@ -3187,6 +3298,18 @@ aboutModal.addEventListener("click", (e) => {
         scheduleLayout();
       };
       img.addEventListener("load", updateAspect, { once: true });
+      // Native lazy-loading defers the network fetch for thumbnails well
+      // outside the viewport instead of firing all ~200 of them at once on
+      // page load - this is most of what was behind "lags on slower
+      // laptops when scrolling, and some images load slowly": every
+      // thumbnail was competing for bandwidth and main-thread decode time
+      // immediately, on every visit, even ones the visitor never scrolls
+      // to. decoding="async" additionally keeps a thumbnail's decode off
+      // the main thread so it can't block scroll/input handling, only
+      // relevant risk being a brief flash of a still-decoding image, which
+      // is preferable to janky scrolling.
+      img.loading = "lazy";
+      img.decoding = "async";
       // Capped well above the largest thumbnail size (950px) for retina screens,
       // but still far smaller than a multi-MB original - keeps the gallery snappy.
       img.src = cloudinaryDisplayUrl(url, { width: 1200 });
@@ -3594,13 +3717,28 @@ downloadLink.addEventListener("click", function(e) {
       selectedCount.textContent = `${selectedImages.length} selected`;
     }
 
+    // Large bulk deletes get an extra, more alarming warning *before* the
+    // normal confirm() below, instead of just a bigger single dialog - two
+    // separate prompts are harder to blow through on autopilot (e.g.
+    // habitually hitting "OK" twice) than one dialog with more text in it,
+    // and this is specifically to prevent an accidental mass-delete of the
+    // gallery (a fat-fingered "select all" style click, or forgetting
+    // Delete Images mode is still on from a previous session).
+    const BULK_DELETE_WARNING_THRESHOLD = 20;
+
     async function deleteSelectedImages() {
       if (selectedImages.length === 0) return;
+      if (selectedImages.length >= BULK_DELETE_WARNING_THRESHOLD) {
+        const proceed = confirm(
+          `⚠️ You're about to delete ${selectedImages.length} images at once.\n\n` +
+          `This is a large chunk of the gallery and cannot be undone. Are you SURE you want to continue?`
+        );
+        if (!proceed) return;
+      }
       if (!confirm(`Are you sure you want to delete ${selectedImages.length} image(s)?`)) { return; }
       try {
         const deletePromises = selectedImages.map(async (container) => {
-          const imageUrl = container.dataset.url;
-          const imageId = await findImageIdByUrl(imageUrl);
+          const imageId = await getImageDocId(container);
           if (imageId) {
             await db.collection('images').doc(imageId).delete();
             container.remove();
@@ -3710,8 +3848,7 @@ downloadLink.addEventListener("click", function(e) {
       }
       try {
         const movePromises = selectedImagesForMove.map(async (container) => {
-          const imageUrl = container.dataset.url;
-          const imageId = await findImageIdByUrl(imageUrl);
+          const imageId = await getImageDocId(container);
           if (imageId) {
             await db.collection('images').doc(imageId).update({
               folder: destinationFolder
@@ -3923,8 +4060,7 @@ downloadLink.addEventListener("click", function(e) {
             newTags = mergeTagStrings(previousTags, typedValue);
           }
           if (newTags === previousTags) return true; // nothing changed, skip the write
-          const imageUrl = container.dataset.url;
-          const imageId = await findImageIdByUrl(imageUrl);
+          const imageId = await getImageDocId(container);
           if (imageId) {
             await db.collection('images').doc(imageId).update({ keywords: newTags });
             container.setAttribute('data-keywords', newTags);
@@ -4203,7 +4339,11 @@ function closeEnlargeModal() {
     renameFolderBtn.addEventListener("click", () => {
       const selectedEl = document.querySelector(".folder-list li.selected");
       if (!selectedEl) { alert("Please select a folder to rename."); return; }
-      if (selectedEl.getAttribute("data-filter") === "all") { alert("Cannot rename 'All'."); return; }
+      const filterValue = selectedEl.getAttribute("data-filter");
+      if (filterValue === "all" || filterValue === NEW_THIS_WEEK_FILTER) {
+        alert("Cannot rename 'All' or 'New This Week' - they aren't real folders.");
+        return;
+      }
       renameFolderInput.value = selectedEl.querySelector(".folder-name").textContent;
       renameFolderModal.classList.add("active");
     });
@@ -4221,13 +4361,26 @@ function closeEnlargeModal() {
   
   // Get the folder name to delete
   const folderToDelete = selectedEl.getAttribute("data-filter");
-  if (folderToDelete === "all") { 
-    alert("Cannot delete 'All'."); 
-    return; 
+  // "All" and "New This Week" are both virtual/synthetic categories, not
+  // real folder docs - "All" was already blocked here, but
+  // NEW_THIS_WEEK_FILTER was not, which meant selecting "New This Week"
+  // and clicking Delete Folder fell through to the real deletion flow
+  // below (a harmless no-op against Firestore, since no folder doc or
+  // image actually has that literal value - see NEW_THIS_WEEK_FILTER's
+  // definition - but still surfaced a real confirm() dialog offering to
+  // "delete" it, which is confusing and not actually impossible like it
+  // should be).
+  if (folderToDelete === "all" || folderToDelete === NEW_THIS_WEEK_FILTER) {
+    alert("Cannot delete 'All' or 'New This Week' - they aren't real folders.");
+    return;
   }
-  
-  // Confirm deletion
-  if (!confirm(`Are you sure you want to delete folder "${folderToDelete}"?`)) {
+
+  // Confirm deletion - explicit about what actually happens (the folder
+  // goes away, its images don't: they keep existing, just reassigned to
+  // "All", per deleteFolderFromFirebase()'s batch .update({folder:'all'})
+  // below) since "delete folder" reads ambiguously otherwise and this was
+  // reported as a point of confusion.
+  if (!confirm(`Delete folder "${folderToDelete}"?\n\nThis only removes the folder itself. Its images are NOT deleted - they'll stay in the gallery, moved to "All".`)) {
     return;
   }
   
@@ -4406,7 +4559,7 @@ function closeEnlargeModal() {
             .filter(t => t && !colorWords.has(t.toLowerCase())).join(", ");
           const newTags = colorTag ? mergeTagStrings(withoutOldColor, colorTag) : withoutOldColor;
           if (newTags !== previousTags) {
-            const imageId = await findImageIdByUrl(url);
+            const imageId = await getImageDocId(container);
             if (imageId) {
               await db.collection('images').doc(imageId).update({ keywords: newTags });
               container.setAttribute('data-keywords', newTags);
@@ -4489,6 +4642,8 @@ function closeEnlargeModal() {
           item.className = "submission-image-item";
 
           const thumb = document.createElement("img");
+          thumb.loading = "lazy";
+          thumb.decoding = "async";
           thumb.src = cloudinaryDisplayUrl(url, { width: 300 });
           item.appendChild(thumb);
 
@@ -4512,8 +4667,8 @@ function closeEnlargeModal() {
               // sampled from the Cloudinary URL directly.
               const colorTag = await detectDominantColorTagFromUrl(url);
               const keywords = colorTag || "";
-              await saveImageToFirebase(url, folder, keywords, "submission-image");
-              addImageToGallery(url, folder, keywords, "submission-image", Date.now());
+              const docId = await saveImageToFirebase(url, folder, keywords, "submission-image");
+              addImageToGallery(url, folder, keywords, "submission-image", Date.now(), docId);
               updateFolderCounts();
               renderColorFilterDots();
               addBtn.textContent = "Added";
@@ -4784,23 +4939,58 @@ function closeEnlargeModal() {
     // Reads each row's own fill width back rather than tracking percents
     // in a separate structure, so it stays correct regardless of how many
     // batches (each with their own uploadBatchId) are running at once.
+    // Wall-clock time the current batch started - reset to null whenever
+    // the dock empties out (see below), so a later, unrelated batch gets
+    // its own fresh estimate instead of inheriting a stale start time.
+    let uploadBatchStartTime = null;
+
+    function formatDuration(ms) {
+      const totalSeconds = Math.max(0, Math.round(ms / 1000));
+      if (totalSeconds < 60) return `${totalSeconds}s`;
+      const minutes = Math.floor(totalSeconds / 60);
+      const seconds = totalSeconds % 60;
+      return `${minutes}m ${seconds}s`;
+    }
+
     function updateGlobalUploadProgress() {
       const items = document.querySelectorAll(".upload-dock-item");
       const globalFill = document.getElementById("uploadDockGlobalProgress");
       const countLabel = document.getElementById("uploadDockCount");
+      const etaLabel = document.getElementById("uploadDockEta");
       if (!items.length) {
         if (globalFill) globalFill.style.width = "0%";
         if (countLabel) countLabel.textContent = "0/0";
+        if (etaLabel) etaLabel.textContent = "";
+        uploadBatchStartTime = null;
         return;
       }
+      if (uploadBatchStartTime === null) uploadBatchStartTime = Date.now();
       let percentSum = 0, done = 0;
       items.forEach(item => {
         const fill = item.querySelector(".upload-dock-progress-fill");
         percentSum += fill ? (parseFloat(fill.style.width) || 0) : 0;
         if (item.classList.contains("upload-success") || item.classList.contains("upload-error")) done++;
       });
-      if (globalFill) globalFill.style.width = `${percentSum / items.length}%`;
+      const overallPercent = percentSum / items.length;
+      if (globalFill) globalFill.style.width = `${overallPercent}%`;
       if (countLabel) countLabel.textContent = `${done}/${items.length}`;
+      if (etaLabel) {
+        // Estimated from elapsed time / overall percent so far (not just
+        // done/total), so it updates smoothly as a file mid-upload
+        // progresses instead of only jumping when a whole file finishes.
+        // Held back for the first ~1.5s / first few percent - too little
+        // progress makes for a wildly unstable estimate ("2 hours left"
+        // off of one 30%-progress tick).
+        const elapsedMs = Date.now() - uploadBatchStartTime;
+        if (done >= items.length) {
+          etaLabel.textContent = "Done";
+        } else if (elapsedMs < 1500 || overallPercent < 3) {
+          etaLabel.textContent = "Estimating…";
+        } else {
+          const estimatedTotalMs = elapsedMs / (overallPercent / 100);
+          etaLabel.textContent = `~${formatDuration(estimatedTotalMs - elapsedMs)} left`;
+        }
+      }
     }
 
     // Start upload (non-blocking)
@@ -4864,11 +5054,11 @@ async function processUpload(file, folderValue, keywords, uploadItemId) {
 async function completeUpload(imageUrl, folderValue, combinedKeywords, fileName, uploadItemId) {
   try {
     // Save to Firebase
-    await saveImageToFirebase(imageUrl, folderValue, combinedKeywords, fileName);
+    const docId = await saveImageToFirebase(imageUrl, folderValue, combinedKeywords, fileName);
     console.log(`Image saved to Firebase`);
-    
+
     // Add to gallery
-    addImageToGallery(imageUrl, folderValue, combinedKeywords, fileName, Date.now());
+    addImageToGallery(imageUrl, folderValue, combinedKeywords, fileName, Date.now(), docId);
     updateFolderCounts();
     renderColorFilterDots();
     console.log(`Image added to gallery`);
@@ -5059,6 +5249,9 @@ async function completeUpload(imageUrl, folderValue, combinedKeywords, fileName,
       <span class="upload-dock-title">Uploading <span id="uploadDockCount">0/0</span></span>
       <div class="upload-dock-global-progress">
         <div class="upload-dock-global-progress-fill" id="uploadDockGlobalProgress" style="width: 0%"></div>
+      </div>
+      <div class="upload-dock-stats">
+        <span class="upload-dock-eta" id="uploadDockEta"></span>
       </div>
     </div>
     <div class="upload-dock-header-actions">

--- a/netlify/functions/upload.js
+++ b/netlify/functions/upload.js
@@ -48,8 +48,20 @@ const handler = (event, context, callback) => {
 
   // When Busboy is done parsing
   busboy.on('finish', () => {
-    // Generate a unique public_id to avoid overwriting existing images
-    const uniqueFileName = `${Date.now()}-${fileName}`;
+    // Generate a unique public_id to avoid overwriting existing images.
+    // Date.now() alone collides whenever two uploads sharing the same
+    // filename land in the same millisecond - each request here is its own
+    // Netlify function invocation (a separate process), so there's no
+    // shared in-memory counter to fall back on the way the frontend's
+    // uploadBatchCounter does for its own same-millisecond collision (see
+    // index.html). A random suffix closes that gap regardless of how many
+    // concurrent invocations are in flight. Cloudinary's default upload
+    // behavior overwrites an existing asset at the same public_id, so a
+    // collision here doesn't error - it silently replaces a previously
+    // uploaded image's content with the new one, which is exactly the kind
+    // of "an image quietly disappeared" bug this guards against.
+    const uniqueSuffix = Math.random().toString(36).slice(2, 10);
+    const uniqueFileName = `${Date.now()}-${uniqueSuffix}-${fileName}`;
 
     // Upload to Cloudinary
     const uploadStream = cloudinary.uploader.upload_stream(


### PR DESCRIPTION
## Summary

Addresses a batch of reported issues: color mis-tagging, a page-load visual glitch, data-loss risk, performance, and a few admin-safety gaps.

- **Color detection still tagging fire hydrants/foliage as "gray"**: reproduced for real with a Playwright + Chromium `<canvas>` harness (previous verification only ever used plain Node pixel-array tests, which can't exercise `dominantColorNameFromCanvas()`'s own canvas-downsample step). A saturated subject covering ~15% of frame against a much larger, only mildly desaturated background (overcast light, gravel, muted grass) was reliably losing to the background under the old FLOOR/CAP (0.05/0.25). Fixed by raising CAP to 0.50 and lowering FLOOR to 0.03 — verified this still passes every previously-documented regression shape (small vivid sliver vs. large subject, fully neutral material, etc.) re-run against the same harness.
- **Stability — images could silently vanish**: `delete`/`move`/`edit tags`/`re-tag colors` all resolved which Firestore doc to touch via an ambiguous `url` lookup. The **Find Duplicates** admin tool exists because two images sometimes do share a url — when that happens, the old lookup could silently mutate the *wrong* image's doc, which then just didn't reappear on the next reload with no error anywhere. Every image now carries its actual Firestore doc id from creation, and all mutating call sites use that directly.
- **`upload.js` `public_id` collision**: was `Date.now()-filename` only, which can collide (and Cloudinary silently *overwrites* on a colliding `public_id`) if two same-named uploads land in the same millisecond. Added a random suffix.
- **"Flashes a huge image, then snaps to normal size" on load**: `.image-container` had no size of its own until JS laid it out, so an unconstrained `<img>` at `width:100%/height:100%` rendered at the photo's full intrinsic resolution for a frame. Gave the container a default size matching its own fallback aspect ratio.
- **Scroll lag / slow image loads**: gallery thumbnails now use `loading="lazy"`/`decoding="async"` instead of all ~200 firing at once on page load.
- **Default gallery size**: S → M.
- **Folder deletion safety**: "All" and "New This Week" can no longer be deleted or renamed (previously only "All" was blocked); the delete-folder confirm now explicitly says images move to "All" rather than being deleted (this was already the actual behavior — just wasn't communicated).
- **Bulk delete safety**: selecting 20+ images now shows an extra warning before the normal delete confirmation.
- **Review Submissions button**: restyled green and moved to the top of the admin controls.
- **Upload dock**: progress bar no longer capped at 480px, and now shows an estimated time remaining next to the existing done/total count.

All changes are documented in `CLAUDE.md` for future sessions, following the file's existing conventions.

## Test plan

- [x] `npm test` passes (`tests/upload.test.js`)
- [x] Headless-browser (Playwright + Chromium) smoke test against a stubbed Firestore/Auth, covering:
  - Default selected size is M, `--row-height` is 240px
  - `.image-container` stays bounded (not huge) both immediately after creation and after layout settles
  - Review Submissions button is the first admin button and styled green
  - Upload dock has an ETA element and an uncapped progress bar
  - Deleting the "All" or "New This Week" folder is blocked with an alert
  - Deleting a real folder shows the "images move to All" warning text
  - Selecting 20+ images and deleting shows the extra warning first; dismissing it aborts with nothing deleted; accepting both dialogs deletes as expected
- [x] Reproduced the reported color mis-tagging with a synthetic Canvas harness shaped like the real failures (saturated subject vs. large desaturated background) and confirmed the fix resolves it without regressing prior documented cases
- Not tested: live Cloudinary/Firestore end-to-end (no network access to those services from this sandbox, consistent with prior sessions' limitations noted in `CLAUDE.md`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcSnEwpnx98fuyeCb9irrY)_