### PR TITLE
Fix sidebar reflection jump, lightbox margins/tags, search icon, tag dedupe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1029,6 +1029,107 @@ with admin-only upload/tagging/organizing tools. Deployed on Netlify.
   live Cloudinary (same sandbox limitation as everything else touching it in this repo); the
   `tests/upload.test.js` assertions (`public_id` contains the filename, isn't just the filename)
   still hold.
+- **Sidebar frost strip no longer tears itself down on every relayout (2026-08-01)** — reported as
+  "reflections jump in a weird way" while scrolling. `buildSidebarFrostStrip()` used to gate its
+  whole rebuild (new `<div>`/`<img>` per tile, `strip.innerHTML = ""` first) behind "has the
+  first-column docId list changed since last time", skipping the rebuild entirely otherwise - which
+  sounds like the right optimization, but `layoutGallery()` (and so this) reruns on *every*
+  lazy-loaded thumbnail's own `load` event while scrolling, not just filter/search/add/delete, and
+  each of those can shift row heights (a real aspect ratio replacing the 1.5 fallback) without
+  changing *which* images are first-column. Net effect: most calls skipped the position update too
+  (it lived inside the same gated block), so tiles silently drifted out of sync with the gallery
+  until some later call's membership actually did change, at which point the full rebuild snapped
+  everything to its correct position at once and reset every tile's `<img>` (fresh fetch, opacity
+  back to 0 to fade in again) even for images that hadn't changed - that combined snap+refade is
+  what read as a "jump." Fixed by decoupling the two: positions are now recomputed on *every* call
+  (cheap - just inline style writes), while tile identity is preserved via a `docId`/`url`-keyed
+  `Map` (`frostTilesByKey`) - a tile that's still a first-column image keeps its actual DOM node
+  (and thus its already-loaded `<img>` and faded-in opacity), only tiles that actually stop/start
+  being first-column get removed/created. Verified with a Playwright + hand-rolled Firestore stub
+  (12 synthetic images): calling `buildSidebarFrostStrip()` twice back-to-back with unchanged
+  membership keeps the exact same `<img>` node references and `.loaded` state; hiding one
+  first-column image and rebuilding removes only that image's tile while an unrelated row's tile
+  keeps its node identity (the freed row-slot gets backfilled by whatever sibling the gallery's own
+  flex-wrap reflows into it, which is correct, expected justified-gallery behavior, not a bug in
+  this fix).
+- **Lightbox content is vertically centered again, not top-anchored (2026-08-01)** — reported as
+  unequal top/bottom margins around the enlarged image (and, since it shares the same outer
+  centering, the "Similar" panel). `enlargeImage()`'s `onload` handler was overriding the modal's
+  `justify-content: center` (set when the modal opens) to `flex-start` plus a fixed 20px top/bottom
+  padding once the image's own size was known. That padding was only ever meant to *size* the image
+  (leave room under it for the tags row without overflowing the viewport, via `availableHeight`) -
+  but it got applied a second time as literal CSS padding on top of that. A width-limited (short/
+  wide) image renders shorter than `availableHeight`, so under `flex-start` the unused leftover
+  space all collected below the content (just the fixed 20px above, everything else below); a
+  height-limited (tall) image happened to look fine since it was sized to fill `availableHeight`
+  almost exactly either way. Fixed by simply not re-overriding `justify-content`/padding in the
+  `onload` handler - centering the whole column as a unit means leftover space always splits evenly
+  above and below, for any image shape, the same reasoning already used for centering
+  `.enlarge-main-row` horizontally. Verified via Playwright (synthetic wide/short and tall/narrow
+  images): top/bottom gaps measured equal (195px/195px and 17px/17px respectively) in both branches.
+- **Lightbox tags are no longer truncated, and stay centered while wrapping (2026-08-01)** —
+  `.enlarged-tags` had `white-space: nowrap; text-overflow: ellipsis`, cutting off a long keyword
+  list instead of showing all of it (explicit request: "always show all tags"). Changed to
+  `white-space: normal; word-break: break-word` so a long tag list wraps onto more lines instead of
+  being cut off, with `border-radius` switched from a 999px pill to `var(--radius-lg)` since a full
+  pill radius only reads right on a single line. `.enlarged-tags-container`'s existing
+  row-centered-as-a-unit layout (from the 2026-07-31 rework) already keeps the tags+resolution pair
+  centered under the image regardless of width, and continues to do so once the tags pill grows
+  taller from wrapping - verified via Playwright with a 25-tag keyword string: full text present,
+  wrapped to 3 lines, and the tags pill's horizontal center still landed exactly on the image's
+  (and its column's) own center.
+- **Tag chip input dedupes exact-match tags (2026-08-01)** — `initTagChipInput()`'s `commitPending()`
+  already deduped case-insensitively when a tag was typed then Enter/comma/blur-committed, but two
+  paths around it didn't: `setTags(csv)` loaded a csv string (e.g. an image's existing keywords)
+  into chips verbatim, so a literal duplicate already sitting in Firestore stayed duplicated, and
+  `getValue()` concatenated whatever text was still sitting uncommitted in the input field onto the
+  committed chip list without checking it against them first - so clicking Save immediately after
+  typing a tag that already had a chip (without the field ever blurring) let an exact duplicate
+  through. Both now route through one shared case-insensitive `dedupeTags()` helper (first
+  occurrence's casing wins). This is the single shared implementation `initTagChipInput()` backs
+  every tag field with (Add Image, Publish Queue, Edit Tags), so the fix applies everywhere tags are
+  entered, not just one modal.
+- **Search bar magnifying-glass icon was invisible - real cause found via pixel sampling, not CSS
+  inspection (2026-08-01)** — reported as "can't see the search icon," despite `getComputedStyle()`
+  reporting it at full white/`opacity:1` the whole time (which is exactly why earlier passes assumed
+  it was already fine - this is the same trap the CLAUDE.md history above has hit before: computed
+  styles or DOM assertions aren't proof of what's actually on screen). Confirmed with a headless
+  Chromium screenshot sampled pixel-by-pixel (`pngjs`): the icon rendered as near-black, not white.
+  Root cause, isolated with a ~60-line standalone repro: `#mainImageSearch` (the `<input>`) has its
+  own `backdrop-filter: blur(10px)`. Even though the input is `position: static`, `backdrop-filter`
+  (like `filter`/`transform`/`opacity<1`) makes it establish a stacking context of its own, and a
+  `z-index: auto` stacking context still paints in the same "z-index: 0" bucket as this absolutely-
+  positioned, `z-index: auto` icon - within that bucket, later DOM order paints on top. The input
+  comes after the icon in the markup, so the input (and its blur) was painting over the icon instead
+  of the reverse. Fixed with `z-index: 1` on `.search-bar-icon`, which moves it to the next bucket up
+  - always painted after (on top of) any `z-index: 0` stacking context regardless of DOM order.
+  Confirmed fixed by re-sampling pixels (dark ~24/255 before, 255/255 after) in both the isolated
+  repro and the real page. If another icon/overlay sitting next to a `backdrop-filter` element ever
+  looks "washed out" or dim despite correct-looking computed styles, this exact stacking interaction
+  is the first thing to check - and check with actual rendered pixels, not just computed style
+  values, since those can (and here did) disagree.
+- **Similar-panel thumbnails reuse the gallery's own cached thumbnail URL (2026-08-01)** — reported
+  as loading "relatively slowly." Each of the 9 thumbnails was requesting a fresh
+  `cloudinaryDisplayUrl(url, {width:200})` - not one of `upload.js`'s pre-generated `eager` sizes
+  (1200px/1920px), so Cloudinary has to transform it on the fly the first time anyone asks for that
+  exact size, on top of the network round trip. The main gallery grid already requested
+  `cloudinaryDisplayUrl(url, {width:1200})` for the same image (an eager, pre-generated size) when it
+  first rendered as a thumbnail - reusing that exact URL (via the other container's own `<img>.src`,
+  already resolved) means Cloudinary never has to cold-transform a new size, and since it's the
+  *same* URL as before, the browser's own HTTP cache usually already has it, sometimes making the
+  "fetch" free. Also dropped `loading="lazy"` on these - they're always already on-screen the instant
+  the panel shows, so lazy-loading only adds an intersection-check delay with nothing to defer.
+  Falls back to a fresh width:1200 request only if the source container's own `<img>` is somehow
+  missing. Not benchmarked against a real Cloudinary CDN (same sandbox limitation as everything else
+  touching Cloudinary in this repo) - the reasoning follows the same eager-transform-cache-miss
+  pattern already documented elsewhere in this file for the main lightbox image.
+- **Folder names brighter, sidebar background darker (2026-08-01, explicit requests)** — `.folder-
+  list > li` and `ul.subfolder-list li`'s base (non-selected, non-hover) text color changed from
+  `--text-muted` (#96969f) to `--text` (#ededf0); `.folder-count` deliberately left on `--text-faint`
+  so the name still reads as primary and the count as secondary. `.sidebar`'s frosted background
+  darkened from `rgba(26,26,30,0.82)` to `rgba(16,16,19,0.88)` (closer to `--bg` than
+  `--bg-elevated`, which is what that literal rgba matched) - the floating color/size panels that
+  share the same original rgba value were deliberately left untouched, this was sidebar-only.
 - **Firestore** — three collections: `folders` (name, parent), `images` (url, folder, keywords,
   filename, timestamp), and `submissions` (link, imageUrls, note, timestamp — see "Submit" above).
   Access is controlled by real Firestore security rules now — see "Admin access" below and

--- a/index.html
+++ b/index.html
@@ -268,8 +268,12 @@
   /* Same frosted-glass material as the floating color/size panels
      (rgba(26,26,30,0.85) + blur + border + shadow) instead of a flat
      opaque fill - .sidebar-frost-art (below) gives it real blurred color
-     to diffuse rather than just tinted transparency over nothing. */
-  background-color: rgba(26,26,30,0.82);
+     to diffuse rather than just tinted transparency over nothing.
+     Darkened + slightly more opaque than those panels' own shared value
+     (2026-08-01, explicit request) - closer to --bg (#131316) than
+     --bg-elevated (#1a1a1e) it started from, still translucent enough for
+     .sidebar-frost-art's reflection to read through underneath. */
+  background-color: rgba(16,16,19,0.88);
   border-right: 1px solid var(--border-color);
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
@@ -280,7 +284,7 @@
   height: 100%;
 }
 @supports not (backdrop-filter: blur(20px)) {
-  .sidebar { background-color: var(--bg-elevated); }
+  .sidebar { background-color: var(--bg); }
 }
 
 .sidebar-frost-art {
@@ -399,7 +403,11 @@
       cursor: pointer;
       transition: background-color 0.15s ease, color 0.15s ease;
       text-align: left;
-      color: var(--text-muted);
+      /* Brighter than --text-muted (2026-08-01, explicit request) - folder
+         names were reading as dim/low-contrast against the sidebar's frosted
+         background. .folder-count (unaffected) stays on --text-faint so the
+         name still reads as the primary text and the count as secondary. */
+      color: var(--text);
     }
     .folder-list > li.all {
       font-weight: 600;
@@ -464,7 +472,9 @@
       border-radius: var(--radius-sm);
       cursor: pointer;
       transition: background-color 0.15s ease, color 0.15s ease;
-      color: var(--text-muted);
+      /* Brighter than --text-muted, matching the top-level folder list
+         (2026-08-01) - see .folder-list > li's comment. */
+      color: var(--text);
     }
     ul.subfolder-list li:hover { background-color: rgba(255,255,255,0.06); color: var(--text); }
     ul.subfolder-list li.selected {
@@ -1336,23 +1346,31 @@
 .enlarged-tags {
   display: inline-flex;
   align-items: center;
-  height: 34px;
+  justify-content: center;
+  min-height: 34px;
   box-sizing: border-box;
   background-color: rgba(26, 26, 30, 0.85);
   border: 1px solid var(--border-color);
   color: var(--text);
   font-size: 0.9rem;
-  padding: 0 16px;
-  border-radius: 999px;
+  padding: 8px 16px;
+  /* A full pill (999px) only reads right for a single line - once a long
+     tag list wraps (see white-space below), a 999px radius on a multi-line
+     box makes it look like a stretched capsule instead of a rounded
+     rectangle, so this uses the same moderate radius token as other
+     multi-line surfaces instead. */
+  border-radius: var(--radius-lg);
   max-width: 100%;
-  /* Automatic minimum size: in a row flex container (unlike the previous
-     column layout), a nowrap text item won't shrink below its own
-     min-content width without this, which would let it overflow past
-     max-width instead of actually ellipsizing. */
+  /* Automatic minimum size: in a row flex container, a text item won't
+     shrink below its own min-content width without this. */
   min-width: 0;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  /* Every tag is always shown in full now - no more truncating a long tag
+     list with an ellipsis - so long lists wrap onto more than one line
+     instead of being cut off (word-break covers a single unbroken tag
+     longer than the pill's own max-width). */
+  white-space: normal;
+  word-break: break-word;
+  text-align: center;
   box-shadow: 0 4px 14px rgba(0,0,0,0.3);
 }
 
@@ -1563,6 +1581,23 @@
      thinner glyph anti-aliased down to near-illegibility in testing. */
   color: var(--highlight);
   pointer-events: none;
+  /* 2026-08-01: the icon was reported invisible - confirmed by pixel-
+     sampling a real headless render (getComputedStyle reported this at full
+     white/opacity 1 the whole time, which is why earlier passes assumed it
+     was fine - the bug only shows up in the actual rendered pixels).
+     #mainImageSearch has its own backdrop-filter, which - even though the
+     input is a plain position: static element - makes it establish a
+     stacking context of its own (any of backdrop-filter/filter/transform/
+     opacity<1 does this, not just position+z-index). A stacking context
+     with z-index:auto still slots into the "z-index: 0" paint bucket, the
+     same bucket this absolutely-positioned, z-index:auto icon is already
+     in - and within that bucket, later DOM order paints on top. The input
+     comes after the icon in the markup, so it was painting (and blurring)
+     over the icon instead of the icon showing over the input. A positive
+     z-index here moves the icon into the next bucket up, which always
+     paints after (on top of) any z-index:0 stacking context regardless of
+     DOM order. */
+  z-index: 1;
 }
 .search-bar-icon circle, .search-bar-icon path {
   stroke-width: 2.5;
@@ -2614,7 +2649,10 @@
       return candidates;
     }
 
-    let lastFrostArtKey = "";
+    // Keyed by docId/url so a tile that's still a first-column image across
+    // calls keeps its actual DOM node (and thus its already-loaded <img> and
+    // faded-in opacity) instead of being torn down and recreated.
+    let frostTilesByKey = new Map();
     function buildSidebarFrostStrip() {
       const art = document.getElementById("sidebarFrostArt");
       const galleryEl = document.getElementById("gallery");
@@ -2623,38 +2661,44 @@
 
       const picks = getFirstColumnContainers();
 
-      // Skip the DOM churn (and the re-fetch/re-decode of every tile) of
-      // rebuilding when the actual set of first-column images hasn't
-      // changed since the last build - a plain scroll never gets here at
-      // all, but layoutGallery() does, on every filter/search/add/delete.
-      const key = picks.map(c => c.dataset.docId || c.dataset.url).join("|");
-      if (key !== lastFrostArtKey) {
-        lastFrostArtKey = key;
-        let strip = art.querySelector(".sidebar-frost-strip");
-        if (!strip) {
-          strip = document.createElement("div");
-          strip.className = "sidebar-frost-strip";
-          art.appendChild(strip);
-        }
-        const galleryRect = galleryEl.getBoundingClientRect();
-        const scrollTop = viewport.scrollTop;
+      let strip = art.querySelector(".sidebar-frost-strip");
+      if (!strip) {
+        strip = document.createElement("div");
+        strip.className = "sidebar-frost-strip";
+        art.appendChild(strip);
+      }
+
+      const galleryRect = galleryEl.getBoundingClientRect();
+      const scrollTop = viewport.scrollTop;
+
+      // Reuse existing tiles by identity instead of wiping and rebuilding
+      // the whole strip on every call. layoutGallery() (and so this) reruns
+      // on every lazy-loaded thumbnail's own load event while scrolling, not
+      // just on filter/search/add/delete - a full teardown+rebuild on those
+      // calls reset every tile's <img> (fresh fetch, opacity back to 0 to
+      // fade in again) even for images that hadn't actually changed, which
+      // is what read as the reflection randomly jumping/flickering mid-
+      // scroll. Positions are still recomputed on every call (cheap: just
+      // inline style writes), so the strip never drifts out of sync with
+      // the gallery the way a membership-only rebuild key could leave it.
+      const nextTilesByKey = new Map();
+      const fragment = document.createDocumentFragment();
+      picks.forEach(container => {
+        const key = container.dataset.docId || container.dataset.url;
         // Place each tile over its image's own real box within the
         // gallery's full scrollable content (not just the currently-visible
         // viewport) - rect.top is relative to the current scroll position,
         // so adding scrollTop back gives a position that stays correct
         // regardless of where the page happens to be scrolled to right now.
-        strip.innerHTML = "";
-        const fragment = document.createDocumentFragment();
-        picks.forEach(container => {
-          const rect = container.getBoundingClientRect();
-          const top = Math.round(rect.top - galleryRect.top + scrollTop) - FROST_TILE_BLEED;
-          const height = Math.round(rect.height) + (FROST_TILE_BLEED * 2);
+        const rect = container.getBoundingClientRect();
+        const top = Math.round(rect.top - galleryRect.top + scrollTop) - FROST_TILE_BLEED;
+        const height = Math.round(rect.height) + (FROST_TILE_BLEED * 2);
 
-          const tile = document.createElement("div");
+        let tile = frostTilesByKey.get(key);
+        if (!tile) {
+          tile = document.createElement("div");
           tile.className = "sidebar-frost-tile";
           tile.setAttribute("aria-hidden", "true");
-          tile.style.top = `${top}px`;
-          tile.style.height = `${height}px`;
           // Shown immediately; the picture fades in over it once decoded.
           tile.style.backgroundColor = getContainerGlowColor(container);
 
@@ -2668,11 +2712,26 @@
           img.addEventListener("load", () => img.classList.add("loaded"), { once: true });
           img.src = cloudinaryDisplayUrl(container.dataset.url, { width: FROST_TILE_WIDTH, quality: FROST_TILE_QUALITY });
           tile.appendChild(img);
-          fragment.appendChild(tile);
-        });
-        strip.appendChild(fragment);
-        strip.style.height = `${Math.round(galleryEl.getBoundingClientRect().height + scrollTop)}px`;
-      }
+        }
+        tile.style.top = `${top}px`;
+        tile.style.height = `${height}px`;
+        nextTilesByKey.set(key, tile);
+        // appendChild on a node already in the document moves it rather
+        // than cloning/recreating it, so a reused tile's <img> is never
+        // reloaded - this both reorders tiles to match `picks` and stages
+        // brand-new ones for insertion below.
+        fragment.appendChild(tile);
+      });
+
+      // Anything left over wasn't reused above, so it's no longer a
+      // first-column image - drop it.
+      frostTilesByKey.forEach((tile, key) => {
+        if (!nextTilesByKey.has(key)) tile.remove();
+      });
+      frostTilesByKey = nextTilesByKey;
+
+      strip.appendChild(fragment);
+      strip.style.height = `${Math.round(galleryEl.getBoundingClientRect().height + scrollTop)}px`;
 
       syncSidebarFrostStripPosition();
     }
@@ -4580,16 +4639,38 @@ downloadLink.addEventListener("click", function(e) {
       });
       inputEl.addEventListener("blur", commitPending);
 
+      // Case-insensitive de-dupe, keeping the first occurrence's original
+      // casing/spelling. commitPending() already checks this before pushing
+      // a new chip, but that only guards typing-then-Enter/comma - it never
+      // ran for a csv string loaded wholesale via setTags() (which could
+      // already contain a literal duplicate, e.g. from an image's existing
+      // keywords), nor for text still sitting uncommitted in the input when
+      // getValue() is called directly (Save clicked without the field ever
+      // blurring/committing first). Both of those left an exact duplicate
+      // tag able to reach Firestore.
+      function dedupeTags(list) {
+        const seen = new Set();
+        const result = [];
+        list.forEach(tag => {
+          const key = tag.toLowerCase();
+          if (!seen.has(key)) {
+            seen.add(key);
+            result.push(tag);
+          }
+        });
+        return result;
+      }
+
       inputEl.tagChipsAPI = {
         setTags(csv) {
-          tags = (csv || "").split(",").map(t => t.trim()).filter(Boolean);
+          tags = dedupeTags((csv || "").split(",").map(t => t.trim()).filter(Boolean));
           inputEl.value = "";
           renderChips();
         },
         getValue() {
           const pending = inputEl.value.trim();
           const list = pending ? tags.concat([pending]) : tags;
-          return list.join(", ");
+          return dedupeTags(list).join(", ");
         }
       };
       return inputEl.tagChipsAPI;
@@ -4706,9 +4787,22 @@ downloadLink.addEventListener("click", function(e) {
         const thumb = document.createElement("div");
         thumb.className = "enlarge-similar-thumb";
         const thumbImg = document.createElement("img");
-        thumbImg.src = cloudinaryDisplayUrl(otherContainer.dataset.url, { width: 200 });
+        // Reuse the gallery grid's own thumbnail URL (width: 1200, same as
+        // addImageToGallery()) instead of requesting a fresh width: 200
+        // transform. Two wins: (1) 1200px is one of upload.js's pre-generated
+        // `eager` sizes, unlike 200px, which Cloudinary has to transform on
+        // the fly the first time anyone requests it - a cold-cache delay on
+        // top of the network round trip; (2) since it's the exact same URL
+        // the grid thumbnail already used, the browser's HTTP cache almost
+        // always already has it from when that image rendered in the main
+        // gallery, so this often costs nothing at all. Falls back to
+        // building the width:1200 URL directly if the other container's own
+        // <img> isn't there for some reason. Also dropped loading="lazy" -
+        // these 9 thumbnails are always already on-screen the instant the
+        // panel shows, so lazy-loading only adds an intersection-check
+        // delay with no scroll-deferral benefit to gain from it.
+        thumbImg.src = sourceImg ? sourceImg.src : cloudinaryDisplayUrl(otherContainer.dataset.url, { width: 1200 });
         thumbImg.alt = sourceImg ? sourceImg.alt : "";
-        thumbImg.loading = "lazy";
         thumbImg.decoding = "async";
         thumb.appendChild(thumbImg);
         thumb.addEventListener("click", (e) => {
@@ -4875,10 +4969,17 @@ downloadLink.addEventListener("click", function(e) {
       enlargeImg.style.height = "auto";
     }
 
-    // Position the modal container to position elements from the top
-    enlargeModal.style.justifyContent = "flex-start";
-    enlargeModal.style.paddingTop = `${verticalPadding}px`;
-    enlargeModal.style.paddingBottom = `${verticalPadding}px`;
+    // Deliberately left at justify-content: center / no padding (as set when
+    // the modal was opened, above) rather than switching to flex-start with
+    // a fixed top/bottom padding here. verticalPadding above only sizes the
+    // image (via availableHeight) so there's always room left for the tags
+    // row underneath without overflowing the viewport - it no longer
+    // becomes literal CSS padding. A width-limited (short/wide) image is
+    // shorter than availableHeight, so under flex-start + fixed padding the
+    // unused space collected entirely below the content (equal to
+    // verticalPadding at the top, everything else at the bottom); centering
+    // the whole column instead means the leftover space always splits
+    // evenly above and below, for any image shape.
 
     // Display tags below the image. The resolution readout sits in the same
     // row and shows regardless of whether there are any tags, so the row


### PR DESCRIPTION
## Summary

Fixes for the round of feedback from screenshots:

- **Sidebar reflection jump while scrolling** — `buildSidebarFrostStrip()` tore the whole reflection strip down and rebuilt it (fresh `<img>`s, opacity reset to fade in again) whenever the first-column image set changed, which happens on every lazy-loaded thumbnail's `load` event while scrolling, not just filter/search/add/delete. Now diffs tiles by doc id/url — an unaffected tile keeps its actual DOM node (and already-loaded image), only tiles that actually start/stop being first-column get created/removed. Positions are recomputed on every call so the strip never drifts out of sync either.
- **Lightbox top/bottom margins** — the modal was switching to `justify-content: flex-start` + fixed padding once the image's size was known, so a short/wide image left all the leftover space at the bottom only. Left it centered instead, so margins split evenly for any image shape (also fixes the "Similar" panel's overall vertical position, since it's centered relative to the same row).
- **Lightbox tags always shown in full** — removed the `nowrap` + ellipsis truncation; long tag lists now wrap and stay centered under the image.
- **Search bar icon was actually invisible** — root-caused via pixel sampling (computed styles reported it as fully white/opaque, but rendered pixels were near-black): `#mainImageSearch`'s own `backdrop-filter` promotes it into the same paint bucket as the absolutely-positioned icon, and being later in the DOM it painted on top. `z-index: 1` on the icon fixes the paint order.
- **Similar images loading speed** — the 9 thumbnails were requesting an uncached `width:200` Cloudinary transform; now reuse the gallery's own already-cached `width:1200` (eager, pre-generated) thumbnail URL instead, and dropped `loading="lazy"` since they're always immediately on-screen.
- **Duplicate tags** — the shared tag-chip input now dedupes case-insensitively in both `setTags()` (loading existing keywords) and `getValue()` (uncommitted typed text vs. existing chips), closing two paths that could let an exact duplicate tag through.
- **Folder names brighter / sidebar background darker** — explicit visual requests.

Also answered inline (not a code change): a "Buy me a coffee" button is low effort — it's just a link/embed to a Ko-fi or Buy Me a Coffee page, no backend or payment code needed in this repo.

CLAUDE.md updated with the reasoning/root causes for future sessions, per this repo's own convention.

## Test plan

- [x] `npm test` (existing Jest suite, unrelated backend tests) passes
- [x] Verified all fixes with a Playwright + hand-rolled Firestore/Auth stub harness (synthetic images), per this repo's documented testing pattern for frontend-only changes (no live Cloudinary/Firebase in this sandbox):
  - Sidebar frost tiles keep the same DOM node identity across repeated `buildSidebarFrostStrip()` calls with unchanged membership, and correctly add/remove only the tiles that actually change
  - Lightbox top/bottom gaps measured equal for both a width-limited (short/wide) and height-limited (tall) synthetic image
  - A 25-tag keyword list renders in full, wrapped, still horizontally centered
  - Tag chip dedupe verified for both `setTags()` and pending-text-vs-existing-chip cases
  - Search icon pixel-sampled at full white (255) after the fix, vs. near-black (~24) before
  - Folder text color and sidebar background color computed styles verified
- [x] Visual screenshot check of the full page (sidebar, search bar, About modal)

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EhH4b4AjUkBtj2ukWxgB5D)_