### PR TITLE
Force synonym tags on, fix yellow-tagged-as-brown, add multi-word search

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1146,6 +1146,62 @@ with admin-only upload/tagging/organizing tools. Deployed on Netlify.
     folder names and the color auto-tagger's words) - if a commonly-used tag has no synonyms/
     translations yet, that's expected (not a bug) until `SYNONYM_MAP`/`TRANSLATION_MAP` are extended
     for it.
+  - **Synonym tags forced permanently on, "Synonym Tags: On/Off" toggle removed (2026-08-01)** -
+    reported as "synonyms arent applyed/on when booting the page and i need in admin mode to turn
+    them off and on... Make sure they are forced." Root cause: `synonymTagsEnabled` defaulted to
+    `true` in code, but was persisted to (and re-read from) `localStorage` on every page load -
+    a stray `"false"` written there at some earlier point (an admin test-toggle) silently
+    overrode that default forever after, on that one browser, with nothing on screen indicating
+    synonyms were suppressed - the only way to notice was opening the sidebar and seeing the
+    button already say "Off", and the only fix was toggling it, which only ever fixed *that one
+    browser's* stored value, not the underlying design. A per-browser flag was never a good fit
+    for something meant to always be on - `synonymTagsEnabled` is now a hardcoded `const true`,
+    the `localStorage` read/write is gone, and the `synonymTagsToggleBtn` sidebar button (plus its
+    `updateSynonymTagsToggleBtn()`/click-handler wiring) was removed outright rather than left as
+    dead UI. Every call site that already checked `synonymTagsEnabled` (search matching,
+    the lightbox tag merge) is untouched - it's a `const` now, but the conditional expressions
+    reading it didn't need to change. Verified via Playwright: seeding a real `"false"` into
+    `localStorage` *before* the page loads (reproducing the exact stuck-off scenario) still leaves
+    `synonymTagsEnabled === true` after load, and `#synonymTagsToggleBtn` no longer exists in the
+    DOM.
+  - **Multi-word search (2026-08-01, explicit request: "allow for multiple search words matching...
+    wood statue... steel tools")** - `performSearch()` used to test the *entire* typed string as one
+    literal substring against each image's keywords/name/category/translated/synonym text, so a
+    two-word query like "wood statue" almost never matched anything, even for an image tagged both
+    "wood" and "statue" - tags are comma-separated single words, not phrases, so that exact
+    multi-word run essentially never occurs verbatim in the haystack. Now splits the typed value on
+    whitespace and requires *every* word to appear somewhere in the image's combined haystack (AND
+    across words, OR across fields per word, same substring matching as before per word) - word
+    order doesn't matter ("statue wood" matches the same images as "wood statue"), and each word can
+    come from a different field (one from `keywords`, another from `data-category`). Verified via
+    Playwright with three synthetic images ("wood, statue", "wood, chair", "steel, tools"): "wood
+    statue" matches only the first, "steel tools" matches only the third, and a three-word query
+    ("wood chair statue") that no single image satisfies in full correctly matches nothing - not a
+    superset of "wood" alone.
+  - **Dominant-color detector: yellow/mustard photos were coming back "brown" (2026-08-01)** -
+    reported plainly as "lots of yellow dominant pics are stored in brown, fix that." Root cause,
+    found by hand-computing HSL for real reference colors rather than guessing at thresholds again
+    (the lesson every prior round of this saga already learned the hard way): the brown carve-out
+    in `nameColorFromRgb()` caught any hue in `[15, 50)` with lightness `< 0.45` - but the plain,
+    no-carve-out hue classification a few lines below already draws the orange/yellow boundary at
+    `45` (`h < 45` -> orange, else -> yellow), so the brown carve-out's `50` upper bound reached 5
+    degrees *past* that line into hue territory that would otherwise be yellow, not orange -
+    meaning any sufficiently dark, saturated yellow/gold/mustard pixel (hue 45-50 - confirmed with
+    `rgb(160,130,10)`, a real dark mustard color, at h=48/l=0.33) got diverted to "brown" before it
+    ever reached the yellow check. Fixed by narrowing the carve-out's upper bound from 50 to 45,
+    matching where the plain classification itself already splits orange from yellow - this only
+    changes what the carve-out *catches*, not how it decides once a hue is actually in its range, so
+    genuine dark oranges/browns still inside the narrower 15-45 band (saddle brown at h=25, dark
+    goldenrod at h=43) are completely unaffected. Verified by hand-computing HSL for five real
+    reference colors and confirming against the updated function: dark mustard now correctly returns
+    "yellow" (was "brown"), while saddle brown, dark goldenrod, chocolate, and gold all return the
+    same result as before. Existing images already mistagged "brown" need **Re-tag Colors** run
+    again to pick up this corrected boundary - it isn't automatic. Same sandbox caveat as every
+    other round of this saga: no live Cloudinary access here, so this is verified against real
+    *reference* colors' HSL math, not a live re-tag against the actual reported photos - if another
+    color still comes back wrong after this, get the real `[color detect]` console line for it first
+    (see the `debugLabel` mechanism a few entries above) rather than tuning these boundaries blind
+    again.
   - **Translation search missing "tools"/"planes" - not actually a synonym/translation coupling
     bug (2026-08-01)** - reported as "translation only works for synonyms it seems... i write
     'outil' and i dont get anything for tools... searching 'avions' i dont get planes results."

--- a/index.html
+++ b/index.html
@@ -3041,7 +3041,6 @@
             <button id="findDuplicatesBtn">Find Duplicates</button>
             <button id="retagColorsBtn">Re-tag Colors</button>
             <button id="retagSynonymsBtn">Re-tag Synonyms</button>
-            <button id="synonymTagsToggleBtn">Synonym Tags: On</button>
           </div>
           <hr class="separator">
          <div class="sidebar-admin-section">
@@ -3460,11 +3459,11 @@
      * is why they show up in the lightbox's tag list (enlargeImage() merges
      * them in for display only) but never in Edit Tags or the upload dock,
      * both of which read/write the plain `keywords` field directly.
-     * `synonymTagsEnabled` (persisted to localStorage, toggled via the
-     * sidebar's "Synonym Tags: On/Off" admin button) gates both of those
-     * uses at once - turning it off removes synonyms from the lightbox tag
-     * list *and* from search matching (see performSearch()), not just one
-     * or the other.
+     * `synonymTagsEnabled` gates both of those uses at once (the lightbox
+     * tag list and search matching, see performSearch()) - forced to
+     * `true` permanently (2026-08-01), no on/off switch any more. See its
+     * own declaration below for why the old localStorage-backed toggle was
+     * removed rather than just fixed.
      *
      * Translated tags: fr/de/it/zh/ja translations of the same vocabulary,
      * always computed and always included in search matching (no on/off
@@ -3558,15 +3557,21 @@
       planes: ["avions", "flugzeuge", "aerei", "飞机", "飛行機"],
     };
 
-    // "Synonym Tags: On/Off" (persisted to localStorage) - see the block
-    // comment above for exactly what this gates.
-    let synonymTagsEnabled = true;
-    try {
-      const storedSynonymPref = localStorage.getItem("synonymTagsEnabled");
-      if (storedSynonymPref !== null) synonymTagsEnabled = storedSynonymPref === "true";
-    } catch (error) {
-      console.warn("Could not read synonym tags preference:", error);
-    }
+    // Forced permanently on (2026-08-01, explicit request: "make sure they
+    // are forced") - superseding a localStorage-backed on/off toggle (the
+    // removed "Synonym Tags: On/Off" sidebar button). That design is
+    // exactly what caused "synonyms aren't applied when booting the page":
+    // the flag defaulted to `true` in code, but a stray "false" written to
+    // a real browser's localStorage (from an earlier admin test-toggle)
+    // silently overrode that default on every later page load, with
+    // nothing on screen to indicate synonyms were suppressed - the only
+    // way to notice was opening the sidebar and seeing the button already
+    // say "Off", and the only way to fix it *for that one browser* was
+    // toggling it back. A per-browser, easily-forgotten-about flag was
+    // never a good fit for a feature meant to always be on by default -
+    // there's no stored preference to go stale any more, and nothing left
+    // to accidentally leave off.
+    const synonymTagsEnabled = true;
 
     function normalizeTagList(keywordsCsv) {
       return (keywordsCsv || "").split(",").map(t => t.trim().toLowerCase()).filter(Boolean);
@@ -3970,7 +3975,6 @@
     const duplicatesList = document.getElementById("duplicatesList");
     const retagColorsBtn = document.getElementById("retagColorsBtn");
     const retagSynonymsBtn = document.getElementById("retagSynonymsBtn");
-    const synonymTagsToggleBtn = document.getElementById("synonymTagsToggleBtn");
 
     // Delete Image elements
     const deleteImageBtn = document.getElementById("deleteImageBtn");
@@ -4306,10 +4310,24 @@
   const searchTerm = mainImageSearch.value.toLowerCase();
 
   // If search is empty, just respect the current folder filter
-  if (searchTerm === "") {
+  if (searchTerm.trim() === "") {
     filterImages(currentFolderFilter);
     return;
   }
+
+  // Multi-word search (2026-08-01, "allow for multiple search words
+  // matching... wood statue... steel tools") - each whitespace-separated
+  // word has to match *somewhere* in the image's combined haystack (AND
+  // across words), not the whole typed string as one literal substring -
+  // "wood statue" used to only match an image whose keywords/name/category
+  // happened to contain that exact five-character-plus-space run, which in
+  // practice was almost never (tags are comma-separated single words, not
+  // phrases), so a two-word search came back empty even for an image
+  // tagged both "wood" and "statue". Word order/position doesn't matter -
+  // "statue wood" matches the same images "wood statue" does - and a word
+  // can come from any field (one from `keywords`, another from
+  // `data-category`, etc.), same as the single-word case already allowed.
+  const searchWords = searchTerm.split(/\s+/).filter(Boolean);
 
   const allImages = document.querySelectorAll(".image-container");
   allImages.forEach(imgContainer => {
@@ -4329,9 +4347,9 @@
     // derived.
     const translatedKeywords = (imgContainer.dataset.translatedKeywords || "").toLowerCase();
     const synonymKeywords = synonymTagsEnabled ? (imgContainer.dataset.synonymKeywords || "").toLowerCase() : "";
+    const haystack = `${imgName} ${keywords} ${category} ${translatedKeywords} ${synonymKeywords}`;
 
-    const matchesSearch = imgName.includes(searchTerm) || keywords.includes(searchTerm) || category.includes(searchTerm)
-      || translatedKeywords.includes(searchTerm) || synonymKeywords.includes(searchTerm);
+    const matchesSearch = searchWords.every(word => haystack.includes(word));
     imgContainer.classList.toggle("hidden", !(matchesSearch && imageMatchesColorFilter(imgContainer)));
   });
   scheduleLayout();
@@ -4820,7 +4838,22 @@ contributorsModal.addEventListener("click", (e) => {
         if (l > 0.90) return 'white';
         return 'gray';
       }
-      if (h >= 15 && h < 50 && l < 0.45) return 'brown';
+      // Upper bound 45 (2026-08-01, was 50) - "lots of yellow dominant pics
+      // are stored in brown". This carve-out is meant to catch a *darkened
+      // orange* (rust, terracotta, wood) reading as brown rather than
+      // orange - but the plain hue-only classification below already draws
+      // the orange/yellow line at 45 (h < 45 -> orange, else -> yellow), so
+      // a 50 upper bound here reached 5 degrees past that line into hue
+      // territory that would otherwise be *yellow*, not orange, diverting
+      // any sufficiently dark, saturated yellow/gold/mustard pixel (hue
+      // 45-50, e.g. rgb(160,130,10) at h=48) into "brown" before it ever
+      // reached the yellow check. Confirmed with real reference colors: a
+      // dark mustard (h=48, l=0.33) now correctly falls through to yellow,
+      // while genuine dark oranges/browns actually in the 15-45 hue band
+      // (saddle brown h=25, dark goldenrod h=43) are unaffected and still
+      // read as brown - this narrows what the carve-out catches, it
+      // doesn't change how it decides once a hue is in range.
+      if (h >= 15 && h < 45 && l < 0.45) return 'brown';
       if (h >= 15 && h < 60 && l >= 0.45 && l < 0.88 && s < 0.35) return 'beige';
       if (h < 15 || h >= 345) return 'red';
       if (h < 45) return 'orange';
@@ -7549,19 +7582,6 @@ function closeEnlargeModal() {
       alert(`Re-tagged synonyms/translations for ${containers.length} image(s): ${changed} changed${failed ? `, ${failed} failed` : ""}.`);
     }
     retagSynonymsBtn?.addEventListener("click", reevaluateAllSynonymTags);
-
-    // "Synonym Tags: On/Off" switch - see the block comment near
-    // SYNONYM_MAP for exactly what synonymTagsEnabled gates.
-    function updateSynonymTagsToggleBtn() {
-      if (synonymTagsToggleBtn) synonymTagsToggleBtn.textContent = `Synonym Tags: ${synonymTagsEnabled ? "On" : "Off"}`;
-    }
-    synonymTagsToggleBtn?.addEventListener("click", () => {
-      synonymTagsEnabled = !synonymTagsEnabled;
-      try { localStorage.setItem("synonymTagsEnabled", String(synonymTagsEnabled)); }
-      catch (error) { console.warn("Could not persist synonym tags preference:", error); }
-      updateSynonymTagsToggleBtn();
-    });
-    updateSynonymTagsToggleBtn();
 
     /********************************************************
      * Review Submissions


### PR DESCRIPTION
## Summary

Follow-up fixes on top of #50 (already merged) — three more real-usage reports:

- **Synonym tags forced permanently on.** Reported as "synonyms arent applyed/on when booting the page and i need in admin mode to turn them off and on... Make sure they are forced." Root cause: `synonymTagsEnabled` defaulted to `true` in code but was also persisted to/re-read from `localStorage`, so a stray `"false"` written there at some earlier point (an admin test-toggle) silently overrode the default forever on that browser, with no visible indicator. Removed the "Synonym Tags: On/Off" toggle and its `localStorage` persistence entirely — `synonymTagsEnabled` is now a hardcoded `const true`.
- **Dominant-color detector: yellow/mustard photos were coming back "brown".** The brown carve-out in `nameColorFromRgb()` covered hue `[15, 50)`, but the plain hue classification a few lines below already splits orange/yellow at 45 — so the carve-out reached 5° past that line into yellow's own territory, diverting dark saturated yellow/gold/mustard pixels into "brown" before they ever reached the yellow check. Narrowed the upper bound to 45. Genuine dark browns/oranges (still inside 15–45) are unaffected.
- **Multi-word search.** `performSearch()` used to test the entire typed string as one literal substring, so "wood statue" almost never matched anything even for an image tagged both "wood" and "statue". Now splits on whitespace and requires every word to match somewhere in the image's combined haystack (AND across words).

See `CLAUDE.md` for full root-cause write-ups.

## Test plan

- [x] `npm test` passes
- [x] Verified via Playwright: seeding a real `"false"` into `localStorage` before load still leaves `synonymTagsEnabled === true` and the toggle button gone from the DOM; `nameColorFromRgb(160,130,10)` (dark mustard) now returns `"yellow"` while `saddleBrown`/`gold` reference colors are unaffected; three synthetic images confirm "wood statue" and "steel tools" each match only their intended image, and a three-word query with no full match returns nothing
- [ ] Not exercised against live Cloudinary/Firebase (sandbox limitation, consistent with the rest of this repo) — **existing images already mistagged "brown" need an admin to run "Re-tag Colors" again** to pick up the corrected boundary; it isn't automatic

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WLqaQBgRuWFTXD38S416DH)_