### PR TITLE
Make search tolerant of typos (missing/extra/wrong letters)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4306,6 +4306,43 @@
     // often than resize/filter.
     document.querySelector(".main-content")?.addEventListener("scroll", scheduleFrostArtSync, { passive: true });
 
+    // Levenshtein edit distance, used by fuzzyWordMatchesToken() below to let
+    // search tolerate typos (a missing letter, an extra letter, a wrong
+    // letter) instead of requiring an exact substring match.
+    function levenshteinDistance(a, b) {
+      const m = a.length, n = b.length;
+      if (m === 0) return n;
+      if (n === 0) return m;
+      const dp = new Array(n + 1);
+      for (let j = 0; j <= n; j++) dp[j] = j;
+      for (let i = 1; i <= m; i++) {
+        let prev = dp[0];
+        dp[0] = i;
+        for (let j = 1; j <= n; j++) {
+          const temp = dp[j];
+          dp[j] = a[i - 1] === b[j - 1] ? prev : 1 + Math.min(prev, dp[j], dp[j - 1]);
+          prev = temp;
+        }
+      }
+      return dp[n];
+    }
+
+    // "painted wood" / "paintd wood" should both surface the same images -
+    // a missing or extra letter in a search word shouldn't hide a real
+    // match. Exact substring (either direction) is still checked first
+    // since it's cheap and covers the common case (including partial words
+    // like "wood" matching a "woodgrain" tag); the edit-distance fallback
+    // only kicks in when that fails, with a threshold that scales with word
+    // length so a 1-letter typo on a short word doesn't accidentally also
+    // accept a completely different short word.
+    function fuzzyWordMatchesToken(word, token) {
+      if (!word || !token) return false;
+      if (token.includes(word) || word.includes(token)) return true;
+      if (Math.abs(word.length - token.length) > 2) return false;
+      const threshold = word.length <= 4 ? 1 : word.length <= 7 ? 2 : 3;
+      return levenshteinDistance(word, token) <= threshold;
+    }
+
     function performSearch() {
   const searchTerm = mainImageSearch.value.toLowerCase();
 
@@ -4348,8 +4385,11 @@
     const translatedKeywords = (imgContainer.dataset.translatedKeywords || "").toLowerCase();
     const synonymKeywords = synonymTagsEnabled ? (imgContainer.dataset.synonymKeywords || "").toLowerCase() : "";
     const haystack = `${imgName} ${keywords} ${category} ${translatedKeywords} ${synonymKeywords}`;
+    const haystackTokens = haystack.split(/[^a-z0-9]+/).filter(Boolean);
 
-    const matchesSearch = searchWords.every(word => haystack.includes(word));
+    const matchesSearch = searchWords.every(word =>
+      haystack.includes(word) || haystackTokens.some(token => fuzzyWordMatchesToken(word, token))
+    );
     imgContainer.classList.toggle("hidden", !(matchesSearch && imageMatchesColorFilter(imgContainer)));
   });
   scheduleLayout();


### PR DESCRIPTION
## Summary
- Searching "painted wood" or "paintd wood" (missing a letter) now both surface images tagged e.g. `painted, wood` — a missing/extra/wrong letter in a search word no longer hides a match that should otherwise show up.
- Adds a Levenshtein-distance fallback (`fuzzyWordMatchesToken`) used per search word against the image's tokenized keywords/name/category/translated/synonym haystack. The existing exact-substring check (cheap, covers the common case like `wood` matching `woodgrain`) still runs first; the edit-distance check only kicks in when that fails, with a threshold that scales with word length so a typo on a short word doesn't accidentally match an unrelated short word.
- Multi-word AND-across-words behavior (added 2026-08-01) is unchanged — each word still has to match somewhere in the haystack, just fuzzily now instead of requiring an exact substring.

## Test plan
- [x] `npm test` (existing Jest suite) passes
- [x] Standalone Node check of the extracted matching logic: `"paintd wood"` and `"paintted wood"` both match a `"painted, wood, old"` haystack; unrelated words (`"xyz"`, `"metal"` against `"steel, tools"`) still correctly don't match; existing substring behavior (`"wood"` matching `"woodgrain"`) and word-order independence (`"statue wood"` vs `"wood, statue"`) are unaffected
- [ ] Manual verification in a live browser against real Firestore/gallery data (no live Firebase access in this sandboxed session)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GrcsYVyLG7iMSyMRznyxF4)_