### PR TITLE
Rebuild mobile navigation as a slide-in drawer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1705,6 +1705,75 @@ with admin-only upload/tagging/organizing tools. Deployed on Netlify.
       a color then confirming the button only wrote updates for the containers actually tagged with
       that color (a same-count, same-id check against a small mixed-color fake gallery) - not the
       other loaded images.
+  - **Mobile navigation rebuilt as a slide-in drawer (2026-08-02, "current mobile version is
+    impossible to navigate")** - before changing anything, took an actual screenshot (Playwright,
+    375×667 viewport, the repo's usual stubbed-Firestore harness) of the *shipped* site rather than
+    guessing at the cause from the CSS alone, and it confirmed the report was not an exaggeration:
+    `.sidebar` was an always-visible flex column that only ever *shrank* at narrower breakpoints
+    (270px → 230px → 200px → 140px), never left the layout - at 375px wide that left barely ~215px
+    (under 60% of the screen) for the actual gallery, folder names truncated to 1-2 characters
+    ("cre...", "c..."), and the floating size-selector panel overlapped the gallery on top of that.
+    Every piece of navigation was crammed into a sliver too narrow for a thumb to reliably hit.
+    Replaced with a standard off-canvas drawer pattern below a new `768px` breakpoint (chosen to
+    cover real phones in portrait - including the wider ones like the 430px-CSS-width iPhone Pro
+    Max - while leaving 769-900px, an in-between tablet range, on the existing reduced-but-still-
+    inline sidebar unchanged):
+    - `.sidebar` becomes `position: fixed`, off-screen by default (`transform: translateX(-100%)`),
+      sliding in via a new `.mobile-open` class - `--mobile-drawer-width: min(82vw, 300px)` caps it
+      so it never eats the *entire* screen even on the narrowest phones. `--sidebar-width` itself
+      drops to `0` for the whole `<=768px` range (replacing the old 200px/140px shrink-steps) since
+      the sidebar no longer participates in `.main-container`'s flex layout at all here - every
+      other rule that reads `var(--sidebar-width)` for offsetting content (the search bar's `left`,
+      `#imageModal`'s `padding-left`, etc.) collapses to "no reserved space" for free, without
+      having to touch each of those individually.
+    - A new hamburger button (`#mobileMenuBtn`, hidden above the breakpoint) opens it;
+      `#sidebarBackdrop` (a permanently-in-DOM but inert `opacity:0; pointer-events:none` overlay,
+      gated purely by an `.active` class so it costs nothing outside mobile) dims the gallery behind
+      it and doubles as a tap-anywhere-to-close target; `#sidebarMobileCloseBtn` is a dedicated close
+      affordance inside the drawer itself. `openMobileDrawer()`/`closeMobileDrawer()` are the only
+      two functions that ever touch these classes, so every trigger goes through one shared path
+      rather than each toggling state independently and risking drift. Also locks `.main-content`'s
+      own scroll (`overflow: hidden`, not `document.body` - `.main-content` is the actual scrolling
+      element here) while open, so the gallery can't be scrolled "through" the dimmed backdrop on a
+      touch device.
+    - Closing is wired into the actions that make sense to auto-dismiss for, rather than requiring
+      an explicit tap every time: picking a folder (delegated on `#folderList`, since
+      `renderFolders()` rebuilds its `<li>`s from scratch), any admin action button in
+      `.sidebar-footer` (Add Image, Delete Images, Re-tag Colors, Admin Log In, etc. - all of them
+      open a modal or a select-then-act mode against the gallery, which the drawer would otherwise
+      sit on top of), and the brand's own `goToHomeAll()`. A `resize` listener also closes it if the
+      viewport crosses back above 768px (e.g. rotating a phone to landscape) - without this, the
+      backdrop's `.active` class would have nothing to ever clear it, since `.sidebar`'s drawer CSS
+      simply stops applying once the media query no longer matches, leaving a stuck dark overlay
+      over the whole page.
+    - The About/Submit/Contributors floating pills (see earlier entries in this file for their
+      history) are hidden outright below 768px rather than shrunk further or dropped to their own
+      row - three separate absolutely-positioned pills (plus, at the 769-900px tablet tier, an
+      entire extra row just to fit them) was exactly the kind of "eating vertical space the gallery
+      needed more, and fussier to tap accurately than a normal list item" pattern this whole rework
+      was meant to fix. They're not gone, just relocated: `.sidebar-mobile-links` inside the drawer
+      (`#mobileAboutBtn`/`#mobileContributorsBtn`/`#mobileSubmitBtn`) are separate buttons wired to
+      the exact same modal-opening logic as the originals, rather than the same DOM elements
+      physically moved (which would have required either duplicating unique ids or fighting to keep
+      one element's position in sync across two entirely different layout contexts - both worse
+      options than two small buttons doing the same thing).
+    - `.main-content`'s `padding-top` at `<=768px` collapses to `calc(var(--header-height) + 16px)`
+      (was 156px/154px at the old 640px/420px tiers) - reclaiming the vertical space that used to be
+      spent on the About/Submit/Contributors "own row" layout, now that they're not in the top bar
+      at all on mobile.
+    - **Verified end-to-end via Playwright** (375×667 viewport, `hasTouch`/`isMobile`, the repo's
+      usual stubbed-Firestore harness): a before/after screenshot comparison (the gallery's own
+      rendered width went from ~214px/57% of viewport to ~354px/94%, and `main-content`'s top
+      padding from 154px to 68px); the drawer starts closed, opens via the hamburger with the
+      backdrop active and background scroll locked, and closes via a folder click, a backdrop click,
+      the drawer's own close button, an admin action button (confirmed it also still opens that
+      button's own modal correctly), and a mobile-only About link (confirmed it also still opens the
+      real About modal); no `document.body` horizontal overflow at any point; and the rotate/resize
+      edge case (drawer open, then resized past 768px) leaves the backdrop cleared rather than stuck
+      on screen. The lightbox was also spot-checked open at this viewport width - unaffected, no
+      horizontal overflow, nav arrows and caption pills still visible (the caption pill row's own
+      content already ran slightly past the viewport edge before this change at very narrow widths -
+      pre-existing and unrelated to the sidebar, out of scope for this rework).
 - **`netlify/functions/upload.js`** — receives multipart uploads (Busboy), pushes the file to
   Cloudinary, pre-generates 1200px/1920px derived sizes (`eager`) so the frontend's
   `cloudinaryDisplayUrl()` requests don't transform on first view. Cloudinary's `public_id` used to

--- a/index.html
+++ b/index.html
@@ -2907,13 +2907,145 @@
   .main-content { padding-top: 128px; }
 }
 
+/* ====================================================
+   Mobile navigation (2026-08-02, <=768px)
+   ====================================================
+   Below this, the sidebar previously stayed visible as an always-present
+   flex column shrinking down to 140px wide (see the old --sidebar-width
+   200px/140px steps this block replaces) - confirmed via screenshot to be
+   a real, severe usability problem, not just a cosmetic squeeze: on a
+   375px-wide phone that left barely ~215px (under 60% of the screen) for
+   the actual gallery, with folder names truncating to 1-2 characters
+   ("cre...", "c...") and every piece of navigation crammed into a sliver
+   nothing bigger than a thumb could reliably tap - "impossible to
+   navigate" was an accurate description, not an exaggeration.
+   Replaced with a standard mobile drawer pattern instead: .sidebar becomes
+   a fixed, off-canvas panel (--mobile-drawer-width wide, capped so it
+   never eats the *entire* viewport) that slides in over the gallery via
+   .mobile-open, triggered by the new .mobile-menu-btn hamburger in the
+   top bar and dismissed via the backdrop, the drawer's own close button,
+   or (see the script) picking a folder / tapping one of the mobile-only
+   About/Submit/Contributors links inside it. --sidebar-width itself drops
+   to 0 for this whole range (rather than shrinking further at 640px/420px
+   the way it used to) since the sidebar no longer participates in the
+   flex layout at all here - every other rule that reads
+   var(--sidebar-width) (the search bar's left inset, modal padding-left,
+   etc.) collapses to "no reserved space" for free, without having to
+   touch each of those individually.
+   The About/Submit/Contributors floating pills are hidden outright rather
+   than shrunk further - three separate absolutely-positioned pills (plus,
+   below 900px, an extra row just to fit them) was eating real vertical
+   space the gallery needed more, on top of being fussier to tap
+   accurately than normal list items. They're not gone, just relocated:
+   equivalent buttons inside the drawer (.sidebar-mobile-links) call the
+   exact same modal-opening logic. */
+@media (max-width: 768px) {
+  :root {
+    --sidebar-width: 0px;
+    --mobile-drawer-width: min(82vw, 300px);
+  }
+  .about-btn, .contributors-btn, .submit-reference-btn { display: none; }
+  .mobile-menu-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    flex-shrink: 0;
+    background-color: rgba(15, 15, 17, 0.82);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    color: var(--text);
+    cursor: pointer;
+    padding: 0;
+  }
+  .mobile-menu-btn svg { width: 20px; height: 20px; }
+  .sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: var(--mobile-drawer-width);
+    /* Off-screen by default - .mobile-open (toggled by
+       toggleMobileDrawer() in the script) is the only thing that ever
+       slides it in, so it's always reachable through one code path. */
+    transform: translateX(-100%);
+    transition: transform 0.28s ease;
+    /* Above the gallery/top bar/floating panels/modals (up to 1200-ish)
+       so nothing underneath can intercept a tap while it's open, but
+       still well below the lightbox (15000+) - the two are never
+       meant to be open at the same time, but this ordering means a
+       stray open drawer could never visually block the lightbox if it
+       somehow were. */
+    z-index: 5000;
+    box-shadow: 4px 0 24px rgba(0, 0, 0, 0.4);
+  }
+  .sidebar.mobile-open { transform: translateX(0); }
+  .sidebar-mobile-close {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    top: 0.8rem;
+    right: 0.8rem;
+    width: 32px;
+    height: 32px;
+    background: none;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    color: var(--text-muted);
+    font-size: 1.3rem;
+    line-height: 1;
+    cursor: pointer;
+    z-index: 2;
+  }
+  .sidebar-mobile-links {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    margin: 0.6rem 0;
+    padding-bottom: 0.6rem;
+    border-bottom: 1px solid var(--border-color);
+  }
+  .sidebar-mobile-links button {
+    width: 100%;
+    text-align: left;
+    padding: 0.6rem 0.7rem;
+    background-color: rgba(255, 255, 255, 0.04);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    color: var(--text);
+    font-size: 0.9rem;
+    cursor: pointer;
+  }
+  .main-content { padding-top: calc(var(--header-height) + 16px); }
+}
+
+/* Dimmed backdrop behind the mobile drawer - lives outside the drawer's
+   own media query since it's completely inert (zero opacity, pointer-
+   events: none) until toggleMobileDrawer() adds .active, so there's no
+   harm in it existing in the DOM/CSS at any viewport width. */
+.sidebar-backdrop {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.28s ease;
+  z-index: 4900;
+}
+.sidebar-backdrop.active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
 /* --------------------------------------------------
    Responsive layout for narrow windows
    (sidebar and header shrink so nothing overlaps
    or overflows the viewport)
 -------------------------------------------------- */
 @media (max-width: 640px) {
-  :root { --sidebar-width: 200px; --header-height: 52px; }
+  :root { --header-height: 52px; }
   .sidebar { padding: 0.6rem; }
   /* .sidebar-brand's height formula (base CSS) assumes only .sidebar-scroll's
      own 0.8rem padding sits above it - true at the base/900px tiers, but
@@ -2926,22 +3058,17 @@
      measured at 140.6px rendered width against this tier's ~155.2px
      available content width (200px sidebar minus .sidebar's 0.6rem padding
      plus .sidebar-scroll's 0.8rem padding on each side, per the comment
-     above) via a headless render, not guessed - still real headroom left. */
+     above) via a headless render, not guessed - still real headroom left.
+     (--sidebar-width itself no longer shrinks at this tier - see the
+     768px mobile-drawer block above; this font-size is really being
+     measured against --mobile-drawer-width now, which still has more
+     headroom than the old fixed 200px sidebar did.) */
   .sidebar-brand { font-size: 1.6rem; height: calc(var(--header-height) - 1.4rem); }
   .top-search-bar { padding: 8px 12px; padding-left: 0.6rem; gap: 0.6rem; }
-  .about-btn { top: 64px; right: 16px; width: 90px; padding: 8px 10px; font-size: 0.85rem; }
-  .contributors-btn { top: 64px; right: 116px; width: 90px; height: 40px; padding: 8px 10px; font-size: 0.85rem; }
-  /* Dropped to its own row below About/Contributors, same reasoning as the
-     <=420px tier's own override (see its comment) - checked across this
-     entire tier's width range (421-640px) via a headless sweep, and even
-     at the widest end of it, squeezing all three across one row put the
-     outer button's left edge under the sidebar at everything below ~516px,
-     not just at the narrowest phone widths. */
-  .submit-reference-btn { top: 106px; right: 16px; width: 90px; height: 40px; padding: 8px 10px; font-size: 0.85rem; }
   #mainImageSearch { padding: 8px 12px 8px 38px; font-size: 0.85rem; }
   .search-bar-icon { left: 12px; width: 16px; height: 16px; }
   .search-placeholder-fade { left: 38px; font-size: 0.85rem; }
-  .main-content { padding-left: 0.6rem; padding-right: 0.6rem; padding-top: 156px; }
+  .main-content { padding-left: 0.6rem; padding-right: 0.6rem; }
   .floating-controls-row { right: 12px; bottom: 12px; gap: 6px; }
   .size-icon-container { gap: 4px; }
   .size-icon { width: 30px; height: 30px; font-size: 0.72rem; }
@@ -2949,36 +3076,25 @@
   .color-dot { width: 24px; height: 24px; }
 }
 
-/* Extra-narrow phones: shrink the sidebar further. The brand heading
-   shrinks along with it (.sidebar-brand, above) rather than being hidden
-   outright - unlike when it lived in the top search bar, it's no longer
-   competing with the search input for space, so there's no reason to
-   drop it here any more. */
+/* Extra-narrow phones: shrink the drawer's own text further. The brand
+   heading shrinks along with it (.sidebar-brand, above) rather than being
+   hidden outright - unlike when it lived in the top search bar, it's no
+   longer competing with the search input for space, so there's no reason
+   to drop it here any more. */
 @media (max-width: 420px) {
-  :root { --sidebar-width: 140px; --header-height: 52px; }
   /* Same 1.4rem reasoning as the 640px tier above - .sidebar's own 0.6rem
      padding still applies at this tier too. Deliberately left at 1.15rem
      (2026-08-02) rather than scaled up with the base/640px tiers above -
      measured (headless render) at ~101px rendered width against only
      ~95px of available content width at this tier's 140px sidebar, i.e.
      already right at its limit before this change; scaling it up with the
-     other tiers would make an existing tightness worse, not better. */
+     other tiers would make an existing tightness worse, not better.
+     (--sidebar-width no longer shrinks at this tier either - see the
+     768px mobile-drawer block above; a 420px viewport's
+     --mobile-drawer-width comes out to ~344px, well over the old 140px
+     fixed sidebar, so this stays conservative rather than growing back.) */
   .sidebar-brand { font-size: 1.15rem; height: calc(var(--header-height) - 1.4rem); }
   .top-search-bar { padding: 8px 10px; padding-left: 0.6rem; }
-  .about-btn { top: 58px; width: 78px; right: 12px; padding: 6px 8px; font-size: 0.78rem; }
-  .contributors-btn { top: 58px; width: 78px; right: 102px; padding: 6px 8px; font-size: 0.78rem; }
-  /* Dropped to its own row below About/Contributors (2026-08-01), rather
-     than squeezed into the same row - at this tier the sidebar alone
-     (140px) plus About+Contributors' own combined footprint (180px)
-     already leaves only 60px of the 380px reference width for a third
-     button, nowhere near enough for "Submit" at any legible size. Confirmed
-     via a headless render: keeping it on the shared row at a shrunk width
-     still had its left edge landing under the 140px sidebar, where its
-     clicks would have been swallowed the same way the z-index fix above
-     this file exists to prevent for modals. Right-aligned to match About's
-     own right edge since it's now the only button on its row. */
-  .submit-reference-btn { top: 106px; right: 12px; width: 78px; padding: 6px 8px; font-size: 0.78rem; }
-  .main-content { padding-top: 154px; }
 }
 
 .batch-tag-review-content {
@@ -3204,6 +3320,15 @@
     <button id="aboutBtn" class="about-btn">About</button>
 
   <div class="top-search-bar">
+    <!-- Mobile-only hamburger (2026-08-02) - opens .sidebar as a slide-in
+         drawer instead of the sidebar permanently reserving real width on
+         a narrow screen. Hidden entirely above the mobile breakpoint (see
+         .mobile-menu-btn's CSS) - toggleMobileDrawer() in the script. -->
+    <button class="mobile-menu-btn" id="mobileMenuBtn" aria-label="Open menu">
+      <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+      </svg>
+    </button>
     <div class="main-search-container">
       <svg class="search-bar-icon" viewBox="0 0 24 24" fill="none" aria-hidden="true">
         <circle cx="11" cy="11" r="7" stroke="currentColor" stroke-width="2"/>
@@ -3310,6 +3435,14 @@
   </div>
 
 
+  <!-- Mobile-only dimmed backdrop behind the sidebar drawer (2026-08-02) -
+       covers the whole viewport so the gallery underneath can't be
+       accidentally interacted with while the drawer is open, and doubles
+       as a big "tap anywhere to close" target. Hidden/non-interactive
+       (opacity 0; pointer-events: none) until .active is added by
+       toggleMobileDrawer(). -->
+  <div class="sidebar-backdrop" id="sidebarBackdrop"></div>
+
   <!-- MAIN CONTAINER (Sidebar + Main Content) -->
   <div class="main-container">
     <!-- SIDEBAR -->
@@ -3324,9 +3457,25 @@
       <div class="sidebar-frost-art" id="sidebarFrostArt"></div>
       <div class="sidebar-scroll">
         <div class="sidebar-brand" id="sidebarBrand"><span id="sidebarBrandText"></span><span class="sidebar-brand-cursor" id="sidebarBrandCursor">|</span></div>
+        <!-- Mobile-only (2026-08-02) - the sidebar doubles as the mobile
+             nav drawer, so it needs its own close affordance beyond
+             tapping the backdrop. Hidden above the mobile breakpoint. -->
+        <button class="sidebar-mobile-close" id="sidebarMobileCloseBtn" aria-label="Close menu">&times;</button>
         <ul class="folder-list" id="folderList">
           <!-- Folder items will be generated dynamically -->
         </ul>
+        <!-- Mobile-only (2026-08-02) - About/Submit/Contributors live as
+             floating top-right pills on desktop (see those buttons further
+             up this file), which don't fit a phone-width header. Rather
+             than duplicating those exact elements' identity, these are
+             separate buttons wired to the same modals (see the script) -
+             hidden entirely above the mobile breakpoint so they don't
+             clutter the desktop sidebar. -->
+        <div class="sidebar-mobile-links" id="sidebarMobileLinks">
+          <button id="mobileSubmitBtn">Submit a Reference</button>
+          <button id="mobileContributorsBtn">Contributors</button>
+          <button id="mobileAboutBtn">About</button>
+        </div>
         <!-- SIDEBAR FOOTER: Admin Editing Controls -->
         <div class="sidebar-footer">
           <!-- Review Submissions sits at the top, ahead of everything else,
@@ -4928,6 +5077,7 @@
       if (allFolder) highlightSelected(allFolder);
       filterImages("all");
       resetGalleryScroll();
+      closeMobileDrawer();
     }
     document.getElementById("sidebarBrand")?.addEventListener("click", () => {
       if (isBrandIntroDone) goToHomeAll();
@@ -5011,6 +5161,65 @@
         cursorEl.classList.remove("blinking");
         cursorEl.style.display = "none";
       }, 400);
+    });
+
+    /** MOBILE NAVIGATION DRAWER (2026-08-02) **/
+    // Below 768px, .sidebar is a fixed off-canvas drawer (see its own CSS
+    // comment for why - the always-visible shrinking sidebar left almost
+    // no usable width for the actual gallery on a real phone). These are
+    // the only two functions that ever touch .mobile-open/.active, so
+    // every trigger below (hamburger, backdrop, close button, folder
+    // clicks, admin actions, the mobile-only About/Submit/Contributors
+    // links) goes through the same open/close path rather than each
+    // toggling classes independently and risking drifting out of sync.
+    // Locks .main-content's own scroll while open (not document.body,
+    // which isn't the actual scrolling element here - .main-content's
+    // overflow-y: auto is) so the gallery can't be scrolled "through" the
+    // open drawer/backdrop on a touch device.
+    function openMobileDrawer() {
+      document.querySelector(".sidebar")?.classList.add("mobile-open");
+      document.getElementById("sidebarBackdrop")?.classList.add("active");
+      const mainContent = document.querySelector(".main-content");
+      if (mainContent) mainContent.style.overflow = "hidden";
+    }
+    function closeMobileDrawer() {
+      document.querySelector(".sidebar")?.classList.remove("mobile-open");
+      document.getElementById("sidebarBackdrop")?.classList.remove("active");
+      const mainContent = document.querySelector(".main-content");
+      if (mainContent) mainContent.style.overflow = "";
+    }
+    document.getElementById("mobileMenuBtn")?.addEventListener("click", openMobileDrawer);
+    document.getElementById("sidebarBackdrop")?.addEventListener("click", closeMobileDrawer);
+    document.getElementById("sidebarMobileCloseBtn")?.addEventListener("click", closeMobileDrawer);
+    // Folder navigation is the single most common reason to open the
+    // drawer in the first place, so picking one closes it automatically
+    // instead of leaving the admin/visitor to dismiss it separately -
+    // delegated on the list itself (not each <li>'s own click handler
+    // individually) since renderFolders() rebuilds those <li> elements
+    // from scratch on every call.
+    document.getElementById("folderList")?.addEventListener("click", (e) => {
+      if (e.target.closest("li")) closeMobileDrawer();
+    });
+    // Every admin action in the sidebar footer (Add Image, Delete Images,
+    // Re-tag Colors, Admin Log In, etc.) opens a modal or toggles a
+    // select-then-act mode against the gallery underneath - the drawer
+    // needs to be out of the way for any of them, so this closes it for
+    // all of them at once rather than adding the same call individually to
+    // each button's own handler. Delegated on .sidebar-footer for the same
+    // "content gets rebuilt/varies" robustness reason as the folder list.
+    document.querySelector(".sidebar-footer")?.addEventListener("click", (e) => {
+      if (e.target.closest("button")) closeMobileDrawer();
+    });
+    // Rotating a phone from portrait to landscape (or resizing past the
+    // 768px breakpoint some other way) can leave the drawer's CSS no
+    // longer applying to .sidebar (it renders as the normal flex column
+    // again) while .sidebar-backdrop's "active" class - and so its dark
+    // overlay - would otherwise stay stuck over the whole page, since
+    // nothing else would ever think to clear it. Closing on any resize
+    // past the breakpoint is a plain, cheap check - no need for a
+    // matchMedia listener for something this infrequent.
+    window.addEventListener("resize", () => {
+      if (window.innerWidth > 768) closeMobileDrawer();
     });
 
     /** ABOUT JavaScript **/
@@ -5199,6 +5408,27 @@ contributorsModal.addEventListener("click", (e) => {
       if (e.target === submitReferenceModal) {
         submitReferenceModal.classList.remove("active");
       }
+    });
+
+    // Mobile-only equivalents of the About/Contributors/Submit floating
+    // pills (2026-08-02, see .sidebar-mobile-links' own CSS comment) - not
+    // the same elements, just wired to open the exact same modals, so a
+    // phone visitor can reach all three from inside the nav drawer instead
+    // of them not fitting a phone-width header at all. Each closes the
+    // drawer right after opening its modal, same as every other drawer
+    // action - open modal + open drawer would leave two overlays stacked.
+    document.getElementById("mobileAboutBtn")?.addEventListener("click", () => {
+      aboutModal.classList.add("active");
+      closeMobileDrawer();
+    });
+    document.getElementById("mobileContributorsBtn")?.addEventListener("click", () => {
+      contributorsModal.classList.add("active");
+      loadContributorsList();
+      closeMobileDrawer();
+    });
+    document.getElementById("mobileSubmitBtn")?.addEventListener("click", () => {
+      submitReferenceModal.classList.add("active");
+      closeMobileDrawer();
     });
 
     // Mirrors the Add Image modal's file preview (thumbnail + count) so


### PR DESCRIPTION
## Summary

The sidebar used to stay permanently visible at every viewport width, just shrinking down (270px → 230px → 200px → 140px) as the screen got narrower. A screenshot of the shipped site at a real phone width (375px) confirmed this was a genuine, severe usability problem: it left barely ~215px (under 60% of the screen) for the actual gallery, folder names truncated to 1-2 characters ("cre...", "c..."), and every piece of navigation was crammed into a sliver too narrow for a thumb to reliably tap.

This rebuilds mobile navigation as a standard slide-in drawer below a new `768px` breakpoint:

- `.sidebar` becomes a fixed, off-canvas drawer (capped at `min(82vw, 300px)`) that slides in over the gallery instead of permanently reserving layout width.
- A new hamburger button opens it; a dimmed backdrop (tap-anywhere-to-close), the drawer's own close button, picking a folder, or any admin action all close it.
- The About/Submit/Contributors floating pills — which used to force an entire extra header row on narrow screens, eating vertical space the gallery needed more — are hidden below this breakpoint and relocated as equivalent buttons inside the drawer, wired to the same modals.
- Background scroll is locked while the drawer is open, and a resize/rotate past the breakpoint clears a stuck-open drawer instead of leaving the backdrop stuck on screen.

Net result at a 375px-wide viewport: the gallery's own rendered width grew from ~57% to ~94% of the screen, and the vertical space reserved above it shrank from 154px to 68px.

## Test plan

- [x] `npm test` (existing Jest suite) passes
- [x] Verified end-to-end with Playwright at a 375×667 mobile viewport (`hasTouch`/`isMobile`, this repo's documented stubbed-Firestore testing pattern, no live Firebase/Cloudinary in this sandbox):
  - Before/after screenshot comparison of the actual rendered layout
  - Drawer starts closed, opens via the hamburger with the backdrop active and background scroll locked
  - Closes via a folder click, a backdrop click, its own close button, an admin action button (and that button's own modal still opens correctly), and a mobile-only nav link (and its modal still opens correctly)
  - No horizontal page overflow at any point
  - Resizing past the breakpoint (simulating a phone rotating to landscape) clears a drawer left open, instead of leaving the backdrop stuck
  - Lightbox spot-checked open at this viewport width - unaffected
- [ ] Manual check against the live site / a real device (no live Cloudinary/Firebase access in this sandbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lh7Kf1nTsK5vq6B74qZtj2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lh7Kf1nTsK5vq6B74qZtj2)_