### PR TITLE
Fix mobile perf: skip sidebar reflection/blur while drawer closed; don't auto-open About on mobile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1774,6 +1774,54 @@ with admin-only upload/tagging/organizing tools. Deployed on Netlify.
       horizontal overflow, nav arrows and caption pills still visible (the caption pill row's own
       content already ran slightly past the viewport edge before this change at very narrow widths -
       pre-existing and unrelated to the sidebar, out of scope for this rework).
+  - **Mobile drawer follow-up: real performance fix + welcome-screen opt-out (2026-08-02, same day)**
+    - **"Very poorly optimized, lags with an A13 Bionic chip."** Root cause: the mobile drawer above
+      made `.sidebar` a fixed, *always-mounted* element (just transformed off-screen when closed),
+      but its `backdrop-filter: blur(80px)` (doubled twice the same day at explicit request, with no
+      real-device testing possible in this sandbox - see the sidebar-blur history earlier in this
+      file) stayed active the whole time regardless of visibility, and worse,
+      `buildSidebarFrostStrip()`/`syncSidebarFrostStripPosition()` - the decorative reflection
+      strip's rebuild-and-position logic - kept running behind it: the rebuild fires from
+      `layoutGallery()`, which reruns on every lazy-loaded thumbnail's own `load` event while
+      scrolling (not just filter/search/add/delete), and the position sync fires on *every single
+      gallery scroll frame*. On mobile, with the drawer closed, none of this reflection is visible
+      at all - it was continuous, real, wasted DOM/network/GPU-compositing work on every ordinary
+      scroll through the gallery, exactly the shape of thing that reads as "lag" on a real device
+      even though it's invisible in a desktop browser or this sandbox's Playwright harness (which
+      can't measure actual GPU cost, only confirm the work is happening or not).
+      Fixed with a single guard, `isMobileDrawerHidden()` (`window.innerWidth <= 768 &&
+      !.sidebar.classList.contains('mobile-open')`), checked at the top of both
+      `buildSidebarFrostStrip()` and `syncSidebarFrostStripPosition()` - short-circuits all of that
+      work whenever the drawer is genuinely invisible. `.sidebar`'s `backdrop-filter` itself is now
+      `none` by default at `<=768px` and only restored to `blur(80px)` via `.mobile-open` - so the
+      GPU-expensive composite is paid only while the drawer is actually on screen. Since
+      `buildSidebarFrostStrip()`/`syncSidebarFrostStripPosition()` now skip while closed, the
+      reflection can go stale or never get built at all before the drawer opens -
+      `openMobileDrawer()` calls `buildSidebarFrostStrip()` once right after adding `.mobile-open`
+      (which itself calls `syncSidebarFrostStripPosition()` at its own end) to catch it up the moment
+      it's actually needed. Desktop (and the 769-900px tablet tier, which never uses the drawer CSS)
+      is completely unaffected - the guard only ever short-circuits at `<=768px`.
+      **Verified via Playwright** (no live device to profile, so this measures the *mechanism*, not
+      real GPU/frame timing): scrolled a 60-image gallery 15 times on a 375px mobile viewport with
+      the drawer closed - zero `<img>` tiles existed in the reflection strip afterward and
+      `backdrop-filter` computed to `none` throughout, confirming none of that work ran; opening the
+      drawer immediately populated all 46 expected tiles with `blur(80px)` restored, confirming nothing
+      is actually broken, just deferred; the same scroll-and-check on a 1400px desktop viewport still
+      populated tiles normally with `blur(80px)` active the whole time, confirming desktop behavior is
+      unchanged. **If mobile scrolling is still reported as laggy after this, the gallery's own
+      `layoutGallery()`/justified-layout algorithm (unrelated to the sidebar) is the next thing to
+      profile on a real device** - this fix addresses the frosted-sidebar-specific waste, not
+      every possible mobile performance issue.
+    - **First-visit About modal no longer auto-opens on mobile** (explicit request, clarified via a
+      follow-up question - the ask was "turn it off for mobile", not "it's broken, fix it") - the
+      existing `hasVisitedReferencesAdrien` localStorage flag is still set on a mobile visitor's
+      first visit exactly as before (so a later *desktop* visit on the same browser profile still
+      won't show it either - this is "seen it once, ever" semantics, not "seen it once per screen
+      size"), but `aboutModal.classList.add("active")` is now additionally gated on
+      `window.innerWidth > 768`, the same breakpoint the mobile drawer uses. Verified via Playwright:
+      a genuinely fresh profile (no seeded localStorage) at a 375px viewport does not show the About
+      modal but does still set the flag, while the identical fresh-profile setup at a 1400px viewport
+      still auto-opens it as before.
 - **`netlify/functions/upload.js`** — receives multipart uploads (Busboy), pushes the file to
   Cloudinary, pre-generates 1200px/1920px derived sizes (`eager`) so the frontend's
   `cloudinaryDisplayUrl()` requests don't transform on first view. Cloudinary's `public_id` used to

--- a/index.html
+++ b/index.html
@@ -2967,8 +2967,9 @@
     height: 100%;
     width: var(--mobile-drawer-width);
     /* Off-screen by default - .mobile-open (toggled by
-       toggleMobileDrawer() in the script) is the only thing that ever
-       slides it in, so it's always reachable through one code path. */
+       openMobileDrawer()/closeMobileDrawer() in the script) is the only
+       thing that ever slides it in, so it's always reachable through one
+       code path. */
     transform: translateX(-100%);
     transition: transform 0.28s ease;
     /* Above the gallery/top bar/floating panels/modals (up to 1200-ish)
@@ -2979,8 +2980,22 @@
        somehow were. */
     z-index: 5000;
     box-shadow: 4px 0 24px rgba(0, 0, 0, 0.4);
+    /* No blur at all while off-screen (2026-08-02, "very poorly optimized,
+       lags with an A13 Bionic chip") - the base rule's backdrop-filter:
+       blur(80px) is one of the most GPU-expensive effects in CSS, and
+       .sidebar being fixed + always-mounted here meant it (and the
+       reflection strip constantly moving behind it - see
+       isMobileDrawerHidden()) kept recompositing on every gallery scroll
+       frame even though the drawer was fully off-screen and invisible the
+       entire time. Restored only while actually open, below. */
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
   }
-  .sidebar.mobile-open { transform: translateX(0); }
+  .sidebar.mobile-open {
+    transform: translateX(0);
+    backdrop-filter: blur(80px);
+    -webkit-backdrop-filter: blur(80px);
+  }
   .sidebar-mobile-close {
     display: flex;
     align-items: center;
@@ -4188,11 +4203,33 @@
       return candidates;
     }
 
+    // Below the mobile-drawer breakpoint (see .sidebar's own CSS), the
+    // sidebar - and so this whole reflection - is fully off-screen unless
+    // the drawer is actually open. buildSidebarFrostStrip()/
+    // syncSidebarFrostStripPosition() both check this before doing any
+    // work (2026-08-02, "very poorly optimized, lags with an A13 Bionic
+    // chip") - buildSidebarFrostStrip() runs on every layoutGallery() call,
+    // which itself reruns on every lazy-loaded thumbnail's own load event
+    // while scrolling (not just filter/search/add/delete), and
+    // syncSidebarFrostStripPosition() runs on every single gallery scroll
+    // frame - rebuilding/repositioning a strip of blurred reflection tiles
+    // nobody can see was real, continuous, entirely wasted work on every
+    // phone-width visit, exactly the kind of thing that reads as "lag"
+    // scrolling a long gallery on a real device. Skipping both here also
+    // means .sidebar's own backdrop-filter (blur(80px) - expensive on any
+    // device, more so on mobile GPUs) only has to be composited while the
+    // drawer is genuinely visible - see its own CSS for the matching
+    // .mobile-open gate.
+    function isMobileDrawerHidden() {
+      return window.innerWidth <= 768 && !document.querySelector(".sidebar")?.classList.contains("mobile-open");
+    }
+
     // Keyed by docId/url so a tile that's still a first-column image across
     // calls keeps its actual DOM node (and thus its already-loaded <img> and
     // faded-in opacity) instead of being torn down and recreated.
     let frostTilesByKey = new Map();
     function buildSidebarFrostStrip() {
+      if (isMobileDrawerHidden()) return;
       const art = document.getElementById("sidebarFrostArt");
       const galleryEl = document.getElementById("gallery");
       const viewport = document.querySelector(".main-content");
@@ -4290,6 +4327,7 @@
     // The only part of this that runs on every scroll event/frame, so it
     // has to stay this cheap - just a transform, no DOM rebuild.
     function syncSidebarFrostStripPosition() {
+      if (isMobileDrawerHidden()) return;
       const strip = document.querySelector("#sidebarFrostArt .sidebar-frost-strip");
       const viewport = document.querySelector(".main-content");
       if (!strip || !viewport) return;
@@ -5181,6 +5219,13 @@
       document.getElementById("sidebarBackdrop")?.classList.add("active");
       const mainContent = document.querySelector(".main-content");
       if (mainContent) mainContent.style.overflow = "hidden";
+      // buildSidebarFrostStrip()/syncSidebarFrostStripPosition() both skip
+      // their work while the drawer is closed on mobile (see
+      // isMobileDrawerHidden()) - the reflection may be stale, or never
+      // built at all, by the time it's actually opened. Catch it up now
+      // that .mobile-open is set (so isMobileDrawerHidden() no longer
+      // short-circuits these calls).
+      buildSidebarFrostStrip();
     }
     function closeMobileDrawer() {
       document.querySelector(".sidebar")?.classList.remove("mobile-open");
@@ -5248,11 +5293,17 @@ aboutModal.addEventListener("click", (e) => {
 // practical "once per user/pc" equivalent (persists per browser profile,
 // survives reloads and tab closes - unlike the admin auth's deliberately
 // session-only persistence, this is meant to stick).
+// Skipped on mobile entirely (2026-08-02, explicit request) - the flag is
+// still set either way (so a later desktop visit on the same browser
+// profile doesn't show it either - this is "seen it once, ever", not
+// "seen it once per screen size"), only *showing* the modal is gated on
+// viewport width, checked at the same <=768px breakpoint the mobile nav
+// drawer uses.
 try {
   const FIRST_VISIT_KEY = "hasVisitedReferencesAdrien";
   if (!localStorage.getItem(FIRST_VISIT_KEY)) {
     localStorage.setItem(FIRST_VISIT_KEY, "1");
-    aboutModal.classList.add("active");
+    if (window.innerWidth > 768) aboutModal.classList.add("active");
   }
 } catch (e) {
   // localStorage can throw (private-browsing storage restrictions,


### PR DESCRIPTION
## Summary

Two follow-ups to the mobile drawer rebuild, both reported the same day:

**"Very poorly optimized, lags with an A13 Bionic chip."** The mobile drawer made `.sidebar` a fixed, always-mounted element (just transformed off-screen when closed) - but its `backdrop-filter: blur(80px)` stayed active regardless of visibility, and the decorative reflection strip behind it (`buildSidebarFrostStrip()`/`syncSidebarFrostStripPosition()`) kept rebuilding and repositioning on every lazy-loaded thumbnail's `load` event and every single gallery scroll frame - continuous, real, entirely wasted work while the drawer was invisible. That's exactly the shape of thing that reads as "lag" during ordinary scrolling on a real phone, even though it's invisible in a desktop browser.

Fixed with a single guard (`isMobileDrawerHidden()`) checked at the top of both functions - they now short-circuit whenever the drawer is genuinely off-screen at `<=768px`. `.sidebar`'s `backdrop-filter` is `none` by default at that breakpoint, only restored via `.mobile-open`, so the GPU-expensive composite is only paid while the drawer is actually visible. `openMobileDrawer()` rebuilds the strip once right as it opens, since it may have gone stale while hidden. Desktop is completely unaffected.

**The first-visit About modal no longer auto-opens on mobile.** The `hasVisitedReferencesAdrien` flag is still set on a mobile visitor's first visit exactly as before (so a later desktop visit on the same browser profile still won't show it either), but actually showing the modal is now additionally gated on viewport width (`> 768px`).

## Test plan

- [x] `npm test` (existing Jest suite) passes
- [x] Verified with Playwright (no live device to profile, so this confirms the *mechanism* rather than real GPU/frame timing): scrolled a 60-image gallery 15 times on a 375px viewport with the drawer closed - zero reflection tiles existed afterward and `backdrop-filter` computed to `none` throughout; opening the drawer immediately populated all expected tiles with `blur(80px)` restored; the same scroll-and-check on a 1400px desktop viewport still worked normally with blur active throughout
- [x] A genuinely fresh profile (no seeded localStorage) at 375px does not show the About modal but does still set the "seen" flag; the same fresh-profile setup at 1400px still auto-opens it as before
- [ ] Manual check against the live site / a real device (no live Cloudinary/Firebase or real-device profiling access in this sandbox) - if scrolling is still reported as laggy after this, the gallery's own justified-layout algorithm is the next thing to profile, not the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lh7Kf1nTsK5vq6B74qZtj2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lh7Kf1nTsK5vq6B74qZtj2)_