### PR TITLE
Shrink and thicken the brand cursor, add more spacing from the text

### DIFF
--- a/index.html
+++ b/index.html
@@ -653,9 +653,15 @@
        bottom exactly on the text's baseline instead of below it. */
     .sidebar-brand-cursor {
       display: inline-block;
-      width: 2px;
-      height: 1em;
-      margin-left: 2px;
+      /* Thicker and shorter (2026-08-02, "too tall, thin... a bit further
+         from the text") - 1em/2px matched the font's full em-box, taller
+         than "aReference"'s actual cap-height so it stuck up well above the
+         letters; 0.72em approximates a bold serif capital's cap-height
+         instead. Widened 2px -> 3px and given more breathing room via
+         margin-left 2px -> 8px. */
+      width: 3px;
+      height: 0.72em;
+      margin-left: 8px;
       background-color: currentColor;
     }
     .sidebar-brand-cursor.blinking {


### PR DESCRIPTION
## Summary
- Follow-up to #61 (the baseline-alignment fix) — this commit landed after #61 had already merged, so it never made it in. Rebased onto latest `main` (on top of #62) and reopened here.
- The brand cursor's `height: 1em` matched the font's full em-box, which is taller than "aReference"'s actual cap-height, so it still stuck up noticeably above the letters even after the baseline-alignment fix in #61.
- `height` reduced to `0.72em` (closer to a bold serif capital's cap-height), `width` increased `2px -> 3px` for a slightly thicker bar, and `margin-left` increased `2px -> 8px` for more breathing room from the text.

## Test plan
- [x] `npm test` (existing Jest suite, unaffected) — passes
- [x] Verified visually via a minimal Playwright + Chromium repro (isolated markup/CSS/JS extracted from `index.html`) — cursor now reads noticeably shorter/thicker with more spacing, still flush with the text baseline

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPQrEp3RRxR2QSmBTV9pee)_