### PR TITLE
Fix RawImage.fromCanvas embedding bug + hide leaked mobile-drawer buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -6189,6 +6189,24 @@ contributorsModal.addEventListener("click", (e) => {
       return normalizeVector(Array.from(image_embeds.data));
     }
 
+    // RawImage.fromCanvas() doesn't exist on @xenova/transformers@2.17.2
+    // (confirmed live, 2026-08-02: "TypeError: RawImage.fromCanvas is not a
+    // function" - a real, verified mistake, not a hypothetical one) - that
+    // method was apparently a later addition, and pinning an older,
+    // more-established version was deliberate (see the block comment above
+    // this section) specifically to avoid depending on newer, less-certain
+    // API surface, which makes it worth fixing here rather than upgrading
+    // the pinned version blind. RawImage.fromBlob() is used instead - a
+    // long-standing, far more commonly documented entry point for this
+    // library (every "classify an uploaded file" browser example uses it) -
+    // fed via canvas.toBlob(), a plain standard browser API with no
+    // dependency-version uncertainty of its own.
+    function canvasToBlob(canvas) {
+      return new Promise((resolve, reject) => {
+        canvas.toBlob(blob => blob ? resolve(blob) : reject(new Error('canvas.toBlob() returned null')), 'image/png');
+      });
+    }
+
     // Local File about to be uploaded (upload wizard step 2's "Suggest
     // Tags"). Mirrors detectDominantColorTag()'s exact shape: reuse
     // decodeToCanvas() (already handles the HEIC-detection/fallback-decode
@@ -6200,7 +6218,8 @@ contributorsModal.addEventListener("click", (e) => {
       try {
         const { RawImage } = await loadClipModule();
         const canvas = await decodeToCanvas(file);
-        return await embedRawImage(RawImage.fromCanvas(canvas), onProgress);
+        const rawImage = await RawImage.fromBlob(await canvasToBlob(canvas));
+        return await embedRawImage(rawImage, onProgress);
       } catch (err) {
         console.warn(`Could not compute tag-suggestion embedding for ${file.name}:`, err);
         return null;
@@ -6228,7 +6247,8 @@ contributorsModal.addEventListener("click", (e) => {
         canvas.width = img.naturalWidth;
         canvas.height = img.naturalHeight;
         canvas.getContext('2d').drawImage(img, 0, 0);
-        return await embedRawImage(RawImage.fromCanvas(canvas), onProgress);
+        const rawImage = await RawImage.fromBlob(await canvasToBlob(canvas));
+        return await embedRawImage(rawImage, onProgress);
       } catch (err) {
         console.warn(`Could not compute tag-suggestion embedding for ${url}:`, err);
         return null;

--- a/index.html
+++ b/index.html
@@ -2961,6 +2961,19 @@
    accurately than normal list items. They're not gone, just relocated:
    equivalent buttons inside the drawer (.sidebar-mobile-links) call the
    exact same modal-opening logic. */
+/* Base (non-media-query) default: these three exist unconditionally in the
+   DOM, but every rule that actually styles them - including their own
+   `display` - lived only inside the <=768px media query below, with
+   nothing declaring a default state above that width. That's the same
+   "flashes all the admin buttons" shape this file already hit once for the
+   sidebar's admin controls (see the CSS default-hidden fix noted elsewhere
+   in this stylesheet) - a real bug, not a hypothetical one: at desktop
+   widths these three fall back to plain unstyled buttons (no border-radius,
+   no background, default block sizing) sitting inline in the middle of the
+   normal sidebar, confirmed from a real screenshot. The <=768px block below
+   already sets `display` on all three when it wants them shown, so this
+   default only needs to cover the "otherwise" case. */
+.mobile-menu-btn, .sidebar-mobile-close, .sidebar-mobile-links { display: none; }
 @media (max-width: 768px) {
   :root {
     --sidebar-width: 0px;


### PR DESCRIPTION
## Summary

Follow-up to #62 (merged). That PR's second commit — the actual fix — was pushed *after* #62 had already been merged, so it never made it into `main`. This PR carries that fix forward (rebased onto current `main`), plus one unrelated bug reported live via screenshot while testing.

**1. `RawImage.fromCanvas()` isn't a real method (tag-suggestion feature)**
- Confirmed live in a real browser: `TypeError: RawImage.fromCanvas is not a function` on `@xenova/transformers@2.17.2`. That confirmed the CDN load and `RawImage` import itself worked, just not that specific factory method.
- Switched both call sites (`computeImageEmbedding`, `computeImageEmbeddingFromUrl`) to `RawImage.fromBlob()`, fed via `canvas.toBlob()` — a far more commonly documented entry point, plus a plain standard browser API with no library-version uncertainty.

**2. Mobile drawer nav elements leaking into the desktop layout (pre-existing, unrelated to the above)**
- The hamburger button, the drawer's close button, and its About/Submit/Contributors links (`.mobile-menu-btn`, `.sidebar-mobile-close`, `.sidebar-mobile-links`) only ever had a `display` value inside the `@media (max-width: 768px)` block — nothing declared a default state above that width, so at desktop widths they fell back to plain unstyled buttons rendered inline in the middle of the sidebar (confirmed via screenshot). This predates this branch (from the mobile drawer rebuild, already on `main`) — same "flashes all the admin buttons" shape this file already fixed once for the sidebar's admin controls, just never caught here.
- Fixed with an explicit default `display: none` outside the media query; the existing `<=768px` rules already override it back to visible there.

## Test plan

- [x] `npm test` passes
- [x] Playwright + stubbed Firestore/Auth harness re-run for the embedding fix: same graceful degradation as before (CDN still blocked in this sandbox), zero uncaught errors
- [x] CSS brace-balance sanity check after the mobile-drawer fix
- [ ] Real-browser smoke test against the actual CDN/model for fix #1 — still needed to confirm it resolves the error end-to-end
- [ ] Visual check at a normal desktop width for fix #2 — confirm the hamburger/close/mobile-links no longer appear, and that the mobile drawer (<=768px) still works exactly as before

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_0172HJ2RGVSfK3XeQCNZ7J57