### PR TITLE
Fix "aReference" text jump when brand cursor disappears

### DIFF
--- a/index.html
+++ b/index.html
@@ -5254,7 +5254,15 @@
         if (tick >= totalTicks) {
           clearInterval(cursorEl._blinkOutTimer);
           cursorEl._blinkOutTimer = null;
-          cursorEl.style.display = "none";
+          // Stay invisible via opacity, not display:none (2026-08-02 fix,
+          // confirmed via screenshot: "aReference" jumps left when the
+          // cursor disappears). The cursor sits in the same inline-flex row
+          // as the text (.sidebar-brand-typing) and .sidebar-brand centers
+          // that row as a unit - display:none removes the cursor's 2px+2px-
+          // margin box from the flex layout entirely, shrinking the row's
+          // content width and shifting the centered text. opacity:0 hides
+          // it just as completely while still reserving that space.
+          cursorEl.style.opacity = "0";
           if (onDone) onDone();
         }
       }, 220);
@@ -5308,7 +5316,6 @@
         clearInterval(cursorEl._blinkOutTimer);
         cursorEl._blinkOutTimer = null;
       }
-      cursorEl.style.display = "inline-block";
       cursorEl.style.opacity = "";
       cursorEl.classList.add("blinking");
     });


### PR DESCRIPTION
## Summary

Unrelated to the tag-suggestion work in #62/#64 - reported live via screenshot after merging those.

- `blinkCursorOutThenHide()` (shared by both the "aReference" typewriter intro's own finish and the post-hover fade-out) hid the brand cursor via `display: none`, which fully removes its `2px width + 2px margin` box from the inline-flex row it shares with the brand text (`.sidebar-brand-typing`). Since `.sidebar-brand` centers that row as a unit, losing ~4px of content width shifted the centered "aReference" text left.
- Switched to `opacity: 0` instead - hides the cursor just as completely while still reserving its layout space, so the text no longer moves when it disappears.

## Test plan

- [x] `npm test` passes
- [x] Playwright harness sampling the brand text's rendered x-position every 50ms across the full type-out + blink-to-hide sequence: position settles once typing finishes and then stays bit-for-bit identical (`31.02px` in the harness) through every subsequent blink/hide cycle - zero page errors
- [ ] Visual check in a real browser to confirm the fix reads correctly (colors/timing aside from position weren't touched)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_0172HJ2RGVSfK3XeQCNZ7J57

---
_Generated by [Claude Code](https://claude.ai/code/session_0172HJ2RGVSfK3XeQCNZ7J57)_