### PR TITLE
Allow two automatic color tags when a second dominant color is detected

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1888,6 +1888,51 @@ with admin-only upload/tagging/organizing tools. Deployed on Netlify.
       here - all three verified via the same Playwright + hand-rolled Firestore/Auth stub pattern
       this file's Testing section documents, using real generated PNG fixtures (not data-URI stubs)
       through a local static server - 21 assertions total, zero console errors from app code.
+  - **Dominant-color auto-tagger: up to two color tags instead of always exactly one (2026-08-03,
+    explicit request, with example photos of a two-specimen mineral display, an orange wall behind
+    a green door, and a green cabinet with a yellow/grungy label panel)** — `dominantColorNameFromCanvas()`
+    now returns a comma-joined pair (`"red, green"`) instead of always a single name, when a second
+    hue family is substantial enough to read as a real second subject rather than background noise.
+    No downstream change was needed at any call site: every caller already merges this return value
+    into an image's keywords via `mergeTagStrings()` (or stores it directly when there are nothing
+    else typed yet), and `mergeTagStrings()` already splits its input on commas - a two-name return
+    just becomes two ordinary keywords for free. The single-winner brown/beige/orange/yellow decision
+    (previously inline, only ever run once) was factored out into `classifyHueFamily(name, weight)` so
+    a possible second-place color goes through the *exact* same carve-out the winner does, rather than
+    skipping it. **Threshold tuning, found via the same synthetic-reproduction method this file's whole
+    color-detection saga already established (see the entries above) rather than a live photo**: a
+    ratio against the *winner's own* weight was tried first and rejected - it made the door example
+    fail, since the wall is most of the frame and the door only a modest fraction of it, so the door's
+    weight is well under half the wall's even though it's obviously a real second color to a person
+    looking at the photo. Judging a candidate's weight against the image's *total* vote weight instead
+    (`SECOND_COLOR_MIN_SHARE = 0.15`, i.e. a hue family needs at least 15% of the whole photo's vote
+    weight to count) fits that shape - it only cares whether the second color is a real, non-trivial
+    slice of the photo, regardless of how much bigger the winner is. Also skips 'yellow' as a second
+    color specifically when 'orange' won (`pooledPartner`) - that pixel weight was already pooled into
+    the winner's own brown/beige decision (see the 2026-08-02 entry above), so counting it again as a
+    distinct second color would just be the same already-fixed shadow/highlight-split-vote bug wearing
+    a different hat. Never returns more than two names, even with three or more comparably-large hue
+    families in frame (only the top two are ever considered) - matches "two automatic color tags
+    instead of one," not "however many are detected." **Verified the same way as every prior round of
+    this saga**: extracted the real, shipped `dominantColorNameFromCanvas()`/`nameColorFromRgb()`/
+    `rgbToHsl()` straight out of `index.html` (a small brace-matching parser, not a hand-copy) into a
+    Node harness with a stubbed `document`/canvas reading a synthetic pixel buffer - a 50/50 red+green
+    split (the mineral-display shape) and a 65/35 orange+green split (the wall/door shape) both
+    correctly return two tags; a 90/10 and a 92/8 sliver (an existing regression case from an earlier
+    round, re-run unchanged) both stay single-tag; a same-material lit/shadow yellow split (another
+    existing regression case) still returns plain `"yellow"`, not `"yellow, brown"`; and a three-way
+    even split (red/green/blue) still returns only two names, never three. **Existing images keep
+    whatever single color tag they already have - this only affects newly-detected tags going forward
+    (new uploads, Review Submissions' "Add") and any image an admin re-tags via Re-tag Colors / Re-tag
+    Current Color Filter afterward** - it isn't a backfill and doesn't need to be, since Re-tag Colors
+    already strips every known color word from an image's existing keywords before merging the fresh
+    detection back in, so re-running it against an already-single-tagged image is enough to pick up a
+    second tag if the photo actually has one. Same sandbox caveat as every other round of this saga:
+    no live Cloudinary/Firebase access here, so none of this has been checked against a real uploaded
+    photo end-to-end - if a photo that obviously has two dominant colors still only gets one tag (or
+    vice versa), get its `[color detect]` console line or extend the harness with a case shaped like
+    the failure before retuning `SECOND_COLOR_MIN_SHARE` blind, same standing advice as every pass
+    before this one.
 - **`netlify/functions/upload.js`** — receives multipart uploads (Busboy), pushes the file to
   Cloudinary, pre-generates 1200px/1920px derived sizes (`eager`) so the frontend's
   `cloudinaryDisplayUrl()` requests don't transform on first view. Cloudinary's `public_id` used to

--- a/index.html
+++ b/index.html
@@ -6061,7 +6061,15 @@ contributorsModal.addEventListener("click", (e) => {
     }
 
     // Classifies every sampled pixel (nameColorFromRgb()) and returns the
-    // name with the most total vote-weight. Reads from a small offscreen
+    // name with the most total vote-weight - or, 2026-08-03, two comma-
+    // joined names ("red, green") when a second color is also substantial
+    // enough to read as a real second subject rather than background noise
+    // (see the SECOND_COLOR_MIN_SHARE comment further down). Every call
+    // site already merges this return value into an image's keywords via
+    // mergeTagStrings() (or stores it directly when there are no other
+    // typed tags yet), and mergeTagStrings() already splits its input on
+    // commas, so a two-name return needs no special-casing anywhere else -
+    // it just becomes two ordinary keywords. Reads from a small offscreen
     // copy of the canvas, not the full-resolution original, purely for
     // speed. Each pixel always votes - unlike the previous version, there
     // is no chroma cutoff that excludes a pixel outright and no "almost
@@ -6193,42 +6201,88 @@ contributorsModal.addEventListener("click", (e) => {
       }
       if (votes.size === 0) return null;
 
-      let bestName = null, bestWeight = 0;
-      votes.forEach((weight, name) => { if (weight > bestWeight) { bestWeight = weight; bestName = name; } });
-
-      if (bestName === 'orange' || bestName === 'yellow') {
-        // 2026-08-02: when 'orange' is winning, pool its stats with
-        // 'yellow''s too (if any) before deciding brown/beige - orange and
-        // yellow are adjacent hue families that the *same* lit material
-        // commonly splits across (a lighting-driven few-degree hue shift,
-        // e.g. a painted surface reading ~44° in one patch and ~46° in
-        // another - not a different underlying color), and deciding
-        // "is this dark enough to be brown" from only the orange-hued
-        // half's own average ignores the material's own brighter,
-        // yellow-hued pixels sitting right next to it. Deliberately
-        // one-directional - a 'yellow' win never pools in 'orange' or
-        // becomes 'brown', preserving the existing dark-mustard/gold ->
-        // stays-yellow behavior exactly as before.
-        const yellowWeight = bestName === 'orange' ? (votes.get('yellow') || 0) : 0;
-        const poolWeight = bestWeight + yellowWeight;
-        const poolL = (lSum.get(bestName) || 0) + (bestName === 'orange' ? (lSum.get('yellow') || 0) : 0);
-        const poolS = (sSum.get(bestName) || 0) + (bestName === 'orange' ? (sSum.get('yellow') || 0) : 0);
+      // Resolves one hue-family's raw vote (weight, plus its own lSum/sSum)
+      // into brown/beige/orange/yellow - factored out of what used to be
+      // inline logic that only ever ran once, against whichever name had
+      // the single highest vote. Now called for the winning name AND
+      // (below) a possible second-place name, so both go through the exact
+      // same brown/beige carve-out instead of the second color skipping it.
+      // 2026-08-02: when resolving 'orange', pool its stats with 'yellow''s
+      // too (if any) before deciding brown/beige - orange and yellow are
+      // adjacent hue families that the *same* lit material commonly splits
+      // across (a lighting-driven few-degree hue shift, e.g. a painted
+      // surface reading ~44° in one patch and ~46° in another - not a
+      // different underlying color), and deciding "is this dark enough to
+      // be brown" from only the orange-hued half's own average ignores the
+      // material's own brighter, yellow-hued pixels sitting right next to
+      // it. Deliberately one-directional - resolving 'yellow' never pools
+      // in 'orange' or becomes 'brown', preserving the existing
+      // dark-mustard/gold -> stays-yellow behavior exactly as before.
+      function classifyHueFamily(name, weight) {
+        if (name !== 'orange' && name !== 'yellow') return name;
+        const yellowWeight = name === 'orange' ? (votes.get('yellow') || 0) : 0;
+        const poolWeight = weight + yellowWeight;
+        const poolL = (lSum.get(name) || 0) + (name === 'orange' ? (lSum.get('yellow') || 0) : 0);
+        const poolS = (sSum.get(name) || 0) + (name === 'orange' ? (sSum.get('yellow') || 0) : 0);
         const avgL = poolL / poolWeight;
         const avgS = poolS / poolWeight;
         // Matches the old per-pixel h-range coverage (brown: h in
         // [15,45); beige: h in [15,60)) as closely as an aggregate,
         // no-longer-per-pixel-hue check can - see nameColorFromRgb's
         // comment for why this moved from per-pixel to per-family.
-        if (bestName === 'orange' && avgL < 0.45) bestName = 'brown';
-        else if (avgL >= 0.45 && avgL < 0.88 && avgS < 0.35) bestName = 'beige';
+        if (name === 'orange' && avgL < 0.45) return 'brown';
+        if (avgL >= 0.45 && avgL < 0.88 && avgS < 0.35) return 'beige';
+        return name;
       }
 
-      if (debugLabel) {
-        const breakdown = Array.from(votes.entries()).sort((a, b) => b[1] - a[1])
-          .map(([name, weight]) => `${name}:${weight.toFixed(1)}`).join(', ');
-        console.debug(`[color detect] ${debugLabel} -> ${bestName} (${breakdown})`);
+      const ranked = Array.from(votes.entries()).sort((a, b) => b[1] - a[1]);
+      const [bestNameRaw, bestWeight] = ranked[0];
+      const bestName = classifyHueFamily(bestNameRaw, bestWeight);
+
+      // 2026-08-03: a second automatic color tag, for photos that are
+      // genuinely two-toned rather than one dominant material plus
+      // background/shadow noise - e.g. a red mineral specimen next to a
+      // green one, or an orange wall behind a smaller green door. A ratio
+      // against the *winner's* own weight (tried first) was too strict for
+      // that door case - the wall is most of the frame and the door only a
+      // modest fraction of it, so the door's weight is well under half the
+      // wall's even though it's obviously a real second color to a person
+      // looking at the photo. Judging against the image's *total* vote
+      // weight instead fits that shape: a second hue family only needs to
+      // account for a real, non-trivial slice of the whole photo
+      // (SECOND_COLOR_MIN_SHARE) to count, regardless of how much bigger
+      // the winner is. Also requires the candidate be actually distinct
+      // from the winner once classified - which is also why 'yellow' is
+      // skipped here when 'orange' won: its pixel weight was already
+      // pooled into the winner's own brown/beige decision above, so it
+      // isn't a separate color, just the same material's own lit half (the
+      // exact shadow/highlight-split-vote problem this file already fixed
+      // once for the single-tag case - see nameColorFromRgb's and
+      // classifyHueFamily's own comments). `ranked` is sorted by weight
+      // descending, so the first non-skipped entry is the only one that
+      // could possibly qualify - once it fails the share check, every
+      // later entry (smaller weight) fails it too.
+      const SECOND_COLOR_MIN_SHARE = 0.15;
+      const totalWeight = ranked.reduce((sum, [, weight]) => sum + weight, 0);
+      const pooledPartner = bestNameRaw === 'orange' ? 'yellow' : null;
+      let secondName = null;
+      for (let i = 1; i < ranked.length; i++) {
+        const [name, weight] = ranked[i];
+        if (name === bestNameRaw || name === pooledPartner) continue;
+        if (weight >= totalWeight * SECOND_COLOR_MIN_SHARE) {
+          const classified = classifyHueFamily(name, weight);
+          if (classified !== bestName) secondName = classified;
+        }
+        break;
       }
-      return bestName;
+
+      const result = secondName ? `${bestName}, ${secondName}` : bestName;
+
+      if (debugLabel) {
+        const breakdown = ranked.map(([name, weight]) => `${name}:${weight.toFixed(1)}`).join(', ');
+        console.debug(`[color detect] ${debugLabel} -> ${result} (${breakdown})`);
+      }
+      return result;
     }
 
     // For a local File about to be uploaded (admin upload dock / Publish


### PR DESCRIPTION
## Summary
- The dominant-color auto-tagger (`dominantColorNameFromCanvas()` in `index.html`) previously always picked exactly one winning color name. It now returns up to **two** comma-joined names (e.g. `"red, green"`) when a second hue family is also substantial enough to read as a real second subject in the photo, rather than background/shadow noise — per the request, with examples of a two-specimen mineral display, an orange wall behind a green door, and a green cabinet with a yellow/grungy label.
- The existing single-winner brown/beige/orange/yellow decision logic was factored into a reusable `classifyHueFamily()` helper so a possible second color goes through the exact same carve-out the winner already did.
- No downstream code changes were needed: every call site (`processUpload()`, Review Submissions' "Add", Re-tag Colors, Re-tag Current Color Filter) already merges the detector's return value into an image's keywords via `mergeTagStrings()`, which already splits its input on commas — a two-name return just becomes two ordinary keywords.
- A second color only counts once it's at least 15% of the photo's total color-vote weight (tuned against synthetic reproductions of the examples above, not a ratio to the winner's own weight — a ratio was too strict for a small door against a much larger wall). It's also never the color already pooled into the winner's own brown/beige decision (e.g. 'yellow' when 'orange' won), to avoid resurrecting the shadow/highlight-split-vote bug this file already fixed once.
- Existing images keep whatever single color tag they already have; this only affects newly-detected tags going forward, or images re-tagged via Re-tag Colors / Re-tag Current Color Filter afterward.

## Test plan
- [x] `npm test` (Jest, `tests/upload.test.js`) — passes, unaffected by this change.
- [x] Extracted the real, shipped `dominantColorNameFromCanvas()`/`nameColorFromRgb()`/`rgbToHsl()` out of `index.html` (brace-matching parser, not a hand-copy) into a Node harness with a stubbed canvas/pixel buffer, and verified:
  - A 50/50 red+green split (mineral-display shape) and a 65/35 orange+green split (wall/door shape) both return two tags.
  - A 90/10 and 92/8 sliver (pre-existing regression cases) both stay single-tag.
  - A same-material lit/shadow yellow split (pre-existing regression case) still returns plain `"yellow"`, not `"yellow, brown"`.
  - A three-way even split (red/green/blue) still returns only two names, never three.
- [ ] No live Firebase/Cloudinary access in this environment, so this hasn't been checked against a real uploaded photo end-to-end — same standing caveat as every other round of this file's color-detection work (see `CLAUDE.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VMNi48b4P5tREj7re1Mr7L

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMNi48b4P5tREj7re1Mr7L)_